### PR TITLE
Fix Composer constraints for the MessageQueueBundle bundle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ sudo: false
 language: php
 
 branches:
-  only:
-    - master
-    - /^\d+\.\d+$/
+    only:
+        - master
+        - /^\d+\.\d+$/
 
 php:
     - 5.6
@@ -13,25 +13,37 @@ php:
     - 7.1
 
 cache:
-  directories:
-    - $HOME/.composer
-    - $TRAVIS_BUILD_DIR/vendor
+    directories:
+        - $HOME/.composer/cache
+        - $TRAVIS_BUILD_DIR/vendor
+
+env:
+    - SYMFONY_VERSION=2.8.13
+    - SYMFONY_VERSION=3.0.*
+    - SYMFONY_VERSION=3.1.*
+
+matrix:
+    fast_finish: true
+    allow_failures:
+        - env: SYMFONY_VERSION=3.0.*
+        - env: SYMFONY_VERSION=3.1.*
 
 before_script:
-  - phpenv config-rm xdebug.ini
-  - phpenv config-add travis.php.ini
-  - composer self-update
-  - composer config minimum-stability dev
-  - composer config prefer-stable true
-  - composer config repositories.oro composer https://packagist.orocrm.com
-  - composer require --no-update --dev "phpunit/phpunit:5.7.*"
-  - composer require --no-update --dev "squizlabs/php_codesniffer:2.8.*"
-  - composer require --no-update --dev "phpmd/phpmd:2.6.*"
-  - composer global require fxp/composer-asset-plugin
-  - travis_wait composer update --prefer-dist --optimize-autoloader --no-interaction  --no-suggest --prefer-stable
-  - set +e; DIFF=$(git diff --name-only --diff-filter=ACMR $TRAVIS_COMMIT_RANGE | grep -e ".*\.php$"); set -e;
+    - phpenv config-rm xdebug.ini
+    - phpenv config-add travis.php.ini
+    - composer self-update
+    - composer config minimum-stability dev
+    - composer config prefer-stable true
+    - composer config repositories.oro composer https://packagist.orocrm.com
+    - composer require --no-update --dev "phpunit/phpunit:5.7.*"
+    - composer require --no-update --dev "squizlabs/php_codesniffer:2.8.*"
+    - composer require --no-update --dev "phpmd/phpmd:2.6.*"
+    - composer require --no-update "symfony/symfony:${SYMFONY_VERSION}"
+    - composer global require fxp/composer-asset-plugin
+    - travis_wait composer update --prefer-dist --optimize-autoloader --no-interaction  --no-suggest --prefer-stable
+    - set +e; DIFF=$(git diff --name-only --diff-filter=ACMR $TRAVIS_COMMIT_RANGE | grep -e ".*\.php$"); set -e;
 
 script:
-  - ./vendor/bin/phpunit
-  - ./vendor/bin/phpcs ./src -p --encoding=utf-8 --extensions=php --standard=./build/phpcs.xml
-  - if [[ $DIFF ]]; then ./vendor/bin/phpmd ${DIFF//$'\n'/,} text ./build/phpmd.xml --suffixes php; fi
+    - ./vendor/bin/phpunit
+    - ./vendor/bin/phpcs ./src -p --encoding=utf-8 --extensions=php --standard=./build/phpcs.xml
+    - if [[ $DIFF ]]; then ./vendor/bin/phpmd ${DIFF//$'\n'/,} text ./build/phpmd.xml --suffixes php; fi

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "ext-zip": "*",
         "ext-openssl": "*",
         "ext-mcrypt": "*",
-        "symfony/symfony": "2.8.*, !=2.8.10, <=2.8.13",
+        "symfony/symfony": "2.8.*, !=2.8.10, <=2.8.13|~3.0",
         "twig/twig": "1.29.*",
         "doctrine/orm": "2.5.5",
         "doctrine/doctrine-bundle": "1.6.3",

--- a/src/Oro/Bundle/MessageQueueBundle/composer.json
+++ b/src/Oro/Bundle/MessageQueueBundle/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "require": {
         "php": ">=5.6",
-        "symfony/framework-bundle": "2.3.*",
+        "symfony/framework-bundle": "2.8.*, !=2.8.10|~3.0",
         "oro/message-queue": "dev-master"
     },
     "autoload": {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

As discussed on Slack with @sergeyz, I updated the Composer constraint for the Symfony package making it equal to the other bundle released standalone. Before merging, would it be possible to also allow Symfony `3.x`? I know the whole platform is not ready yet for it, but as this bundle is going to be used standalone and I don't think you're using anything that won't work on a newer Symfony version then it would be cool to allow people to install it on Symfony 3. In the worst case, a contribution can always be made to fix it