### PR TITLE
Fix: Array to string in Report Bundle

### DIFF
--- a/src/Oro/Bundle/ReportBundle/Resources/config/services.yml
+++ b/src/Oro/Bundle/ReportBundle/Resources/config/services.yml
@@ -87,10 +87,10 @@ services:
         tags:
             - { name: validator.constraint_validator, alias: oro_report.report_definition_validator }
 
-    oro_report.validator.report_column_dublicate_validator:
-        class: Oro\Bundle\ReportBundle\Validator\ReportColumnDublicateValidator
+    oro_report.validator.report_column_duplicate_validator:
+        class: Oro\Bundle\ReportBundle\Validator\ReportColumnDuplicateValidator
         tags:
-            - { name: validator.constraint_validator, alias: oro_report.report_column_dublicate_validator }
+            - { name: validator.constraint_validator, alias: oro_report.report_column_duplicate_validator }
 
     oro_report.validator.report_date_grouping_validator:
         class: Oro\Bundle\ReportBundle\Validator\ReportDateGroupingValidator

--- a/src/Oro/Bundle/ReportBundle/Resources/config/validation.yml
+++ b/src/Oro/Bundle/ReportBundle/Resources/config/validation.yml
@@ -5,7 +5,7 @@ Oro\Bundle\ReportBundle\Entity\Report:
     constraints:
         - Oro\Bundle\ReportBundle\Validator\Constraints\ReportDefinitionConstraint:
             groups: [PreQueryValidate]
-        - Oro\Bundle\ReportBundle\Validator\Constraints\ReportColumnDublicateConstraint:
+        - Oro\Bundle\ReportBundle\Validator\Constraints\ReportColumnDuplicateConstraint:
             groups: [PreQueryValidate]
         - Oro\Bundle\ReportBundle\Validator\Constraints\ReportDateGroupingConstraint:
             groups: [PreQueryValidate]

--- a/src/Oro/Bundle/ReportBundle/Resources/translations/validators.en.yml
+++ b/src/Oro/Bundle/ReportBundle/Resources/translations/validators.en.yml
@@ -3,7 +3,7 @@ oro:
         definition:
             columns:
                 mandatory: You must specify at least one column for the report grid
-        dublicate:
+        duplicate:
             columns: You are trying to add several copies of column(s) %columnName% to the report. Only one copy of the column may be added. Please, review the list of columns to remove duplicates.
         date_grouping:
             group_by_mandatory: The date grouping filter requires configuring a grouping column. Please select a unique column (ex. id) from the main entity in the "Grouping" section

--- a/src/Oro/Bundle/ReportBundle/Tests/Unit/Validator/ReportColumnDuplicateValidatorTest.php
+++ b/src/Oro/Bundle/ReportBundle/Tests/Unit/Validator/ReportColumnDuplicateValidatorTest.php
@@ -6,9 +6,9 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Context\ExecutionContextInterface;
 
 use Oro\Bundle\ReportBundle\Entity\Report;
-use Oro\Bundle\ReportBundle\Validator\ReportColumnDublicateValidator;
+use Oro\Bundle\ReportBundle\Validator\ReportColumnDuplicateValidator;
 
-class ReportColumnDublicateValidatorTest extends \PHPUnit_Framework_TestCase
+class ReportColumnDuplicateValidatorTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @var Constraint|\PHPUnit_Framework_MockObject_MockObject
@@ -16,7 +16,7 @@ class ReportColumnDublicateValidatorTest extends \PHPUnit_Framework_TestCase
     protected $constraint;
 
     /**
-     * @var ReportColumnDublicateValidator
+     * @var ReportColumnDuplicateValidator
      */
     protected $validator;
 
@@ -29,7 +29,7 @@ class ReportColumnDublicateValidatorTest extends \PHPUnit_Framework_TestCase
     {
         $this->constraint = $this->getMockBuilder(Constraint::class)->getMock();
         $this->context = $this->getMockBuilder(ExecutionContextInterface::class)->getMock();
-        $this->validator = new ReportColumnDublicateValidator();
+        $this->validator = new ReportColumnDuplicateValidator();
         $this->validator->initialize($this->context);
     }
 
@@ -60,7 +60,7 @@ class ReportColumnDublicateValidatorTest extends \PHPUnit_Framework_TestCase
         $this->validator->validate(null, $this->constraint);
     }
 
-    public function testValidateShouldDoNothingIfColumnsNotDublicated()
+    public function testValidateShouldDoNothingIfColumnsNotDuplicated()
     {
         $this->context->expects($this->never())->method('addViolation');
         $report = new Report();

--- a/src/Oro/Bundle/ReportBundle/Validator/Constraints/ReportColumnDuplicateConstraint.php
+++ b/src/Oro/Bundle/ReportBundle/Validator/Constraints/ReportColumnDuplicateConstraint.php
@@ -4,12 +4,12 @@ namespace Oro\Bundle\ReportBundle\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
-class ReportColumnDublicateConstraint extends Constraint
+class ReportColumnDuplicateConstraint extends Constraint
 {
     /**
      * @var string
      */
-    public $columnIsDublicate = 'oro.report.dublicate.columns';
+    public $columnIsDuplicate = 'oro.report.duplicate.columns';
 
     /**
      * {@inheritdoc}
@@ -24,6 +24,6 @@ class ReportColumnDublicateConstraint extends Constraint
      */
     public function validatedBy()
     {
-        return 'oro_report.report_column_dublicate_validator';
+        return 'oro_report.report_column_duplicate_validator';
     }
 }

--- a/src/Oro/Bundle/ReportBundle/Validator/ReportColumnDuplicateValidator.php
+++ b/src/Oro/Bundle/ReportBundle/Validator/ReportColumnDuplicateValidator.php
@@ -6,9 +6,12 @@ use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\ConstraintValidator;
 
 use Oro\Bundle\ReportBundle\Entity\Report;
-use Oro\Bundle\ReportBundle\Validator\Constraints\ReportColumnDublicateConstraint;
+use Oro\Bundle\ReportBundle\Validator\Constraints\ReportColumnDuplicateConstraint;
 
-class ReportColumnDublicateValidator extends ConstraintValidator
+/**
+ * Class ReportColumnDuplicateValidator
+ */
+class ReportColumnDuplicateValidator extends ConstraintValidator
 {
     /**
      * {@inheritdoc}
@@ -21,17 +24,18 @@ class ReportColumnDublicateValidator extends ConstraintValidator
 
         $definition = json_decode($value->getDefinition(), true);
 
-        /** @var ReportColumnDublicateConstraint $constraint */
-        if (isset($definition['columns']) && $columnNames = $this->checkOnCloumnDublicate($definition['columns'])) {
-            $this->context->addViolation($constraint->columnIsDublicate, ['%columnName%' => $columnNames]);
+        /** @var ReportColumnDuplicateConstraint $constraint */
+        if (isset($definition['columns']) && $columnNames = $this->checkOnColumnDuplicate($definition['columns'])) {
+            $this->context->addViolation($constraint->columnIsDuplicate, ['%columnName%' => $columnNames]);
         }
     }
 
     /**
      * @param array $columns
+     *
      * @return bool
      */
-    private function checkOnCloumnDublicate(array $columns)
+    private function checkOnColumnDuplicate(array $columns)
     {
         $useMap = [];
         $result = [];


### PR DESCRIPTION
Each column in a report definition has an array of data for the function definition if a function is added.  

```
oro_report_form[definition]:{"columns":[{"name":"createdAt","label":"Created At","func":"","sorting":""},{"name":"id","label":"Id","func":{"name":"Count","group_type":"aggregates","group_name":"number","return_type":"integer"},"sorting":""}],"grouping_columns":[{"name":"createdAt","temp-validation-name-803":""}]}
```

The validator uses the `func` value as a string which throws a notice level warning and does not use the actual function name, this then means you cannot have a column used twice in one report if they have differing functions (it does work if you have the column with and without a function)

If you need any changes or want the commit with the typo fix in a separate request please let me know

Cheers
Luke