### PR TITLE
Datagrid divisor option

### DIFF
--- a/src/Oro/Bundle/DataGridBundle/Extension/Formatter/Property/FieldProperty.php
+++ b/src/Oro/Bundle/DataGridBundle/Extension/Formatter/Property/FieldProperty.php
@@ -52,11 +52,29 @@ class FieldProperty extends AbstractProperty
             if ($this->getOr(self::FRONTEND_TYPE_KEY) === self::TYPE_MULTI_SELECT) {
                 $value = explode(',', $value);
             }
+            $value = $this->applyDivisor($value);
         } catch (\LogicException $e) {
             // default value
             $value = null;
         }
 
+        return $value;
+    }
+
+    /**
+     * Apply configured divisor to a numeric raw value
+     *
+     * @param mixed $value
+     * @return float
+     */
+    protected function applyDivisor($value)
+    {
+        if (!is_numeric($value)) {
+            return $value;
+        }
+        if ($divisor = $this->getOr(self::DIVISOR_KEY)) {
+            $value = $value / $divisor;
+        }
         return $value;
     }
 }

--- a/src/Oro/Bundle/DataGridBundle/Extension/Formatter/Property/PropertyInterface.php
+++ b/src/Oro/Bundle/DataGridBundle/Extension/Formatter/Property/PropertyInterface.php
@@ -37,6 +37,7 @@ interface PropertyInterface
     const DATA_NAME_KEY     = 'data_name';
     const TRANSLATABLE_KEY  = 'translatable';
     const FRONTEND_TYPE_KEY = 'frontend_type';
+    const DIVISOR_KEY       = 'divisor';
 
     /**
      * Initialize property for each cell

--- a/src/Oro/Bundle/DataGridBundle/Extension/Totals/Configuration.php
+++ b/src/Oro/Bundle/DataGridBundle/Extension/Totals/Configuration.php
@@ -13,6 +13,7 @@ class Configuration implements ConfigurationInterface
     const TOTALS_LABEL_KEY     = 'label';
     const TOTALS_SQL_EXPRESSION_KEY = 'expr';
     const TOTALS_FORMATTER_KEY      = 'formatter';
+    const TOTALS_DIVISOR_KEY      = 'divisor';
 
     const TOTALS_PER_PAGE_ROW_KEY   = 'per_page';
     const TOTALS_HIDE_IF_ONE_PAGE_KEY = 'hide_if_one_page';
@@ -53,7 +54,10 @@ class Configuration implements ConfigurationInterface
                                 ->scalarNode(self::TOTALS_FORMATTER_KEY)
                                     ->defaultFalse()
                                     ->end()
-                            ->end()
+                                ->scalarNode(self::TOTALS_DIVISOR_KEY)
+                                    ->info('A divisor to divide the starting value by a number before rendering it.')
+                                    ->end()
+                             ->end()
                         ->end()
                     ->end()
                 ->end()

--- a/src/Oro/Bundle/DataGridBundle/Extension/Totals/OrmTotalsExtension.php
+++ b/src/Oro/Bundle/DataGridBundle/Extension/Totals/OrmTotalsExtension.php
@@ -197,6 +197,12 @@ class OrmTotalsExtension extends AbstractExtension
             $column = [];
             if (isset($data[$field])) {
                 $totalValue = $data[$field];
+                if (isset($total[Configuration::TOTALS_DIVISOR_KEY])) {
+                    $divisor = (int) $total[Configuration::TOTALS_DIVISOR_KEY];
+                    if ($divisor != 0) {
+                        $totalValue = $totalValue / $divisor;
+                    }
+                }
                 if (isset($total[Configuration::TOTALS_FORMATTER_KEY])) {
                     $totalValue = $this->applyFrontendFormatting(
                         $totalValue,

--- a/src/Oro/Bundle/DataGridBundle/Resources/doc/backend/extensions/formatter.md
+++ b/src/Oro/Bundle/DataGridBundle/Resources/doc/backend/extensions/formatter.md
@@ -12,6 +12,7 @@ column_name:
     type: field # default value `field`, so this key could be skipped here
     frontend_type: date|datetime|decimal|integer|percent|currency|select|text|html|boolean # optional default string
     data_name: someAlias.someField # optional, key in result that should represent this field
+    divisor: some number # optional if you need to divide a numeric value by a number before rendering it
 ```
 Represents default data field.
 
@@ -107,6 +108,7 @@ column_name:
     method: formatCurrency      # required
     context: []                 # optional
     context_resolver: @callable # optional
+    divisor: some number # optional if you need to divide a numeric value by a number before rendering it
 ```
 Using for format numbers using Oro\Bundle\LocaleBundle\Formatter\NumberFormatter on backend.
 

--- a/src/Oro/Bundle/DataGridBundle/Resources/doc/backend/extensions/totals.md
+++ b/src/Oro/Bundle/DataGridBundle/Resources/doc/backend/extensions/totals.md
@@ -36,6 +36,11 @@ datagrids:
                   label: 'Summary'
                   expr: 'SUM(o.probability)'
                   formatter: percent
+              budget:
+                  label: 'Budget Amount'
+                  expr: 'SUM(o.budget)'
+                  formatter: currency
+                  divisor: 100
               statusLabel:
                   label: oro.sales.opportunity.status.label
 ```
@@ -51,3 +56,4 @@ datagrids:
 - total config can be taken from another total row with **extends** parameter.
 - **per_page** parameter switch data calculation only for current page data
 - if **hide_if_one_page** is true, then this total row will be hidden on full data set.
+- **divisor** if you need to divide the value by a number before rendering it to the user (***not required***)

--- a/src/Oro/Bundle/DataGridBundle/Resources/public/js/app/components/cell-popup-editor-component.js
+++ b/src/Oro/Bundle/DataGridBundle/Resources/public/js/app/components/cell-popup-editor-component.js
@@ -199,6 +199,7 @@ define(function(require) {
 
             var cell = this.options.cell;
             var serverUpdateData = this.getServerUpdateData();
+            this.applyDivisor(serverUpdateData, false);
             this.formState = this.view.getFormState();
             var modelUpdateData = this.view.getModelUpdateData();
             cell.$el.addClass('loading');
@@ -477,6 +478,7 @@ define(function(require) {
                         }, this)
                     ) {
                         var fields = response.hasOwnProperty('fields') ? response.fields : response;
+                        this.applyDivisor(fields, true);
                         var routeParamsRenameMap = _.invert(this.options.save_api_accessor.routeParametersRenameMap);
                         _.each(fields, function(item, i) {
                             var propName = routeParamsRenameMap.hasOwnProperty(i) ? routeParamsRenameMap[i] : i;
@@ -591,6 +593,19 @@ define(function(require) {
          */
         getServerUpdateData: function() {
             return this.view.getServerUpdateData();
+        },
+
+        applyDivisor: function(fields, toResponse) {
+            var metadata = this.options.cell.column.attributes.metadata;
+            var fieldName = metadata.name;
+            if (_.has(metadata, 'divisor')) {
+                if (!isNaN(fields[fieldName])) {
+                fields[fieldName] = toResponse ?
+           	        fields[fieldName] / metadata.divisor
+           	        : 
+           	        fields[fieldName] * metadata.divisor;
+                }
+            }
         }
     });
 

--- a/src/Oro/Bundle/DataGridBundle/Tests/Unit/Extension/Totals/OrmTotalsExtensionTest.php
+++ b/src/Oro/Bundle/DataGridBundle/Tests/Unit/Extension/Totals/OrmTotalsExtensionTest.php
@@ -84,6 +84,7 @@ class OrmTotalsExtensionTest extends OrmTestCase
         $this->assertFalse($resultConfig['grand_total']['per_page']);
         $this->assertFalse($resultConfig['grand_total']['hide_if_one_page']);
         $this->assertEquals('SUM(a.won)', $resultConfig['grand_total']['columns']['wonCount']['expr']);
+        $this->assertEquals(100, $resultConfig['grand_total']['columns']['wonCount']['divisor']);
         $this->assertTrue(isset($resultConfig['total']['columns']['wonCount']));
         $this->assertEquals('SUM(a.won)', $resultConfig['total']['columns']['wonCount']['expr']);
     }
@@ -155,7 +156,7 @@ class OrmTotalsExtensionTest extends OrmTestCase
                         'columns' => [
                             'id' => ['expr' => 'COUNT(a.id)'],
                             'name' => ['label' => 'Grand Total'],
-                            'wonCount' => ['expr' => 'SUM(a.won)']
+                            'wonCount' => ['expr' => 'SUM(a.won)', 'divisor' => 100]
                         ]
                     ]
                 ]

--- a/src/Oro/Bundle/FilterBundle/Filter/FilterUtility.php
+++ b/src/Oro/Bundle/FilterBundle/Filter/FilterUtility.php
@@ -18,6 +18,7 @@ class FilterUtility
     const MIN_LENGTH_KEY    = 'min_length';
     const FORCE_LIKE_KEY    = 'force_like';
     const FORM_OPTIONS_KEY  = 'options';
+    const DIVISOR_KEY       = 'divisor';
     const TYPE_EMPTY        = 'filter_empty_option';
     const TYPE_NOT_EMPTY    = 'filter_not_empty_option';
 

--- a/src/Oro/Bundle/FilterBundle/Filter/NumberFilter.php
+++ b/src/Oro/Bundle/FilterBundle/Filter/NumberFilter.php
@@ -62,6 +62,8 @@ class NumberFilter extends AbstractFilter
             return false;
         }
 
+        $data['value'] = $this->applyDivisor($data['value']);
+
         return $data;
     }
 
@@ -130,5 +132,22 @@ class NumberFilter extends AbstractFilter
         $metadata['formatterOptions'] = $formView->vars['formatter_options'];
 
         return $metadata;
+    }
+
+    /**
+     * Apply configured divisor to a numeric raw value. For filtering this means to multiply the filter value.
+     *
+     * @param mixed $value
+     * @return float
+     */
+    protected function applyDivisor($value)
+    {
+        if (!is_numeric($value)) {
+            return $value;
+        }
+        if ($divisor = $this->getOr(FilterUtility::DIVISOR_KEY)) {
+            $value = $value * $divisor;
+        }
+        return $value;
     }
 }

--- a/src/Oro/Bundle/FilterBundle/Filter/NumberRangeFilter.php
+++ b/src/Oro/Bundle/FilterBundle/Filter/NumberRangeFilter.php
@@ -201,8 +201,14 @@ class NumberRangeFilter extends NumberFilter
                 if (!isset($data['value'])) {
                     $data['value'] = null;
                 }
+                else {
+                    $data['value'] = $this->applyDivisor($data['value']);
+                }
                 if (!isset($data['value_end'])) {
                     $data['value_end'] = null;
+                }
+                else {
+                    $data['value_end'] = $this->applyDivisor($data['value_end']);
                 }
                 break;
         }

--- a/src/Oro/Bundle/FilterBundle/Resources/doc/reference/grid_extension.md
+++ b/src/Oro/Bundle/FilterBundle/Resources/doc/reference/grid_extension.md
@@ -30,6 +30,7 @@ For example:
                     visible: true|false #If set to "false" - filter will not be displayed anywhere in UI. However, one can still set filter's value in backend or via url in frontend
                     force_like: true|false #Different search engines uses different methods for text search. When `force_like` is set to true, text-based filters will use simple `LIKE %%` OR `NOT LIKE %%`statement which depends on a chosen operator
                     min_length: integer #In case of text-based filters this option introduce possibility to ignore filters with less characters then specified. Validation message will also appear
+                    divisor: number #In case of number-based filters this option will filter values rendered with datagrid divisor option.
 
 ```
 

--- a/src/Oro/Bundle/FilterBundle/Tests/Unit/Filter/NumberFilterTest.php
+++ b/src/Oro/Bundle/FilterBundle/Tests/Unit/Filter/NumberFilterTest.php
@@ -70,6 +70,27 @@ class NumberFilterTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider applyProviderForDivisor
+     *
+     * @param array $inputData
+     * @param array $expectedData
+     */
+    public function testApplyForDivisor(array $inputData, array $expectedData)
+    {
+        $ds = $this->prepareDatasource();
+
+        $this->filter->init($this->filterName, [
+            FilterUtility::DATA_NAME_KEY => $this->dataName,
+            FilterUtility::DIVISOR_KEY => 100,
+        ]);
+        $this->filter->apply($ds, $inputData['data']);
+
+        $where = $this->parseQueryCondition($ds);
+
+        $this->assertEquals($expectedData['where'], $where);
+    }
+
+    /**
      * @dataProvider parseDataProvider
      *
      * @param mixed  $inputData
@@ -150,6 +171,103 @@ class NumberFilterTest extends \PHPUnit_Framework_TestCase
                 ],
                 'expected' => [
                     'where' => 'field-name < 6',
+                ],
+            ],
+            'EMPTY' => [
+                'input' => [
+                    'data' => [
+                        'type' => FilterUtility::TYPE_EMPTY,
+                        'value' => null,
+                    ],
+                ],
+                'expected' => [
+                    'where' => 'field-name IS NULL',
+                ],
+            ],
+            'NOT_EMPTY' => [
+                'input' => [
+                    'data' => [
+                        'type' => FilterUtility::TYPE_NOT_EMPTY,
+                        'value' => null,
+                    ],
+                ],
+                'expected' => [
+                    'where' => 'field-name IS NOT NULL',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function applyProviderForDivisor()
+    {
+        return [
+            'GREATER_EQUAL' => [
+                'input' => [
+                    'data' => [
+                        'type' => NumberFilterType::TYPE_GREATER_EQUAL,
+                        'value' => 1,
+                    ],
+                ],
+                'expected' => [
+                    'where' => 'field-name >= 100',
+                ],
+            ],
+            'GREATER_THAN' => [
+                'input' => [
+                    'data' => [
+                        'type' => NumberFilterType::TYPE_GREATER_THAN,
+                        'value' => 2,
+                    ],
+                ],
+                'expected' => [
+                    'where' => 'field-name > 200',
+                ],
+            ],
+            'EQUAL' => [
+                'input' => [
+                    'data' => [
+                        'type' => NumberFilterType::TYPE_EQUAL,
+                        'value' => 3,
+                    ],
+                ],
+                'expected' => [
+                    'where' => 'field-name = 300',
+                ],
+            ],
+            'NOT_EQUAL' => [
+                'input' => [
+                    'data' => [
+                        'type' => NumberFilterType::TYPE_NOT_EQUAL,
+                        'value' => 4,
+                    ],
+                ],
+                'expected' => [
+                    'where' => 'field-name <> 400',
+                ],
+            ],
+            'LESS_EQUAL' => [
+                'input' => [
+                    'data' => [
+                        'type' => NumberFilterType::TYPE_LESS_EQUAL,
+                        'value' => 5,
+                    ],
+                ],
+                'expected' => [
+                    'where' => 'field-name <= 500',
+                ],
+            ],
+            'LESS_THAN' => [
+                'input' => [
+                    'data' => [
+                        'type' => NumberFilterType::TYPE_LESS_THAN,
+                        'value' => 6,
+                    ],
+                ],
+                'expected' => [
+                    'where' => 'field-name < 600',
                 ],
             ],
             'EMPTY' => [


### PR DESCRIPTION
This PR implements #702 . It makes it possible to handle money values as integers. With a new `divisor` option datagrid will always show the correct value.
This implementation supports formatter and totals extensions as well as filtering and inline editing.

If you need any changes please let me know!