### PR TITLE
Fix exception Call to a member function getRoute() on null

### DIFF
--- a/src/Oro/Bundle/EmailBundle/Provider/EmailActivityListProvider.php
+++ b/src/Oro/Bundle/EmailBundle/Provider/EmailActivityListProvider.php
@@ -462,8 +462,13 @@ class EmailActivityListProvider implements
      */
     protected function setOwnerLink($owner, $data)
     {
-        $route = $this->configManager->getEntityMetadata(ClassUtils::getClass($owner))
-            ->getRoute('view');
+        $route = null;
+        $entityMetadata = $this->configManager->getEntityMetadata(ClassUtils::getClass($owner));
+        
+        if(null !== $entityMetadata) {
+            $route = $entityMetadata->getRoute('view');
+        }
+        
         if (null !== $route && $this->authorizationChecker->isGranted('VIEW', $owner)) {
             $id = $this->doctrineHelper->getSingleEntityIdentifier($owner);
             try {


### PR DESCRIPTION
FatalThrowableError in /var/www/orocrm/vendor/oro/platform/src/Oro/Bundle/EmailBundle/Provider/EmailActivityListProvider.php line 473:
Call to a member function getRoute() on null