### PR TITLE
[Tag Bundle] Not accessible all pages with tags

### DIFF
--- a/src/Oro/Bundle/TagBundle/Entity/Repository/TagRepository.php
+++ b/src/Oro/Bundle/TagBundle/Entity/Repository/TagRepository.php
@@ -10,6 +10,7 @@ use Doctrine\ORM\QueryBuilder;
 
 use Oro\Bundle\TagBundle\Entity\Tag;
 use Oro\Bundle\OrganizationBundle\Entity\Organization;
+use Oro\Bundle\TagBundle\Entity\Tagging;
 use Oro\Bundle\TagBundle\Helper\TaggableHelper;
 use Oro\Bundle\UserBundle\Entity\User;
 
@@ -156,6 +157,27 @@ class TagRepository extends EntityRepository
         $recordId = TaggableHelper::getEntityId($resource);
 
         return $this->getTags(ClassUtils::getClass($resource), $recordId, $createdBy, $all, $organization);
+    }
+
+    /**
+     * @param object $entity
+     * @param Tag $tag
+     *
+     * @return Tagging[]
+     */
+    public function getTaggingByEntityAndTag($entity, Tag $tag)
+    {
+        $qb = $this->_em->createQueryBuilder();
+        $qb->select('tagging')->from('OroTagBundle:Tagging', 'tagging')
+            ->where('tagging.entityName = :entityName')
+            ->andWhere('tagging.recordId = :recordId')
+            ->andWhere('tagging.tag = :tag');
+
+        $qb->setParameter('entityName', ClassUtils::getClass($entity))
+            ->setParameter('tag', $tag->getId())
+            ->setParameter('recordId', TaggableHelper::getEntityId($entity));
+
+        return $qb->getQuery()->getResult();
     }
 
     /**

--- a/src/Oro/Bundle/TagBundle/Entity/TagManager.php
+++ b/src/Oro/Bundle/TagBundle/Entity/TagManager.php
@@ -293,14 +293,7 @@ class TagManager
                 );
             }
 
-            $taggingCollection = $tag->getTagging()->filter(
-                function (Tagging $tagging) use ($entity) {
-                    // only use tagging entities that related to current entity
-                    return
-                        $tagging->getEntityName() === ClassUtils::getClass($entity) &&
-                        $tagging->getRecordId() === TaggableHelper::getEntityId($entity);
-                }
-            );
+            $taggingCollection = $this->getTagsRepository()->getTaggingByEntityAndTag($entity, $tag);
 
             /** @var Tagging $tagging */
             foreach ($taggingCollection as $tagging) {
@@ -311,7 +304,7 @@ class TagManager
                 }
             }
 
-            $entry['moreOwners'] = $taggingCollection->count() > 1;
+            $entry['moreOwners'] = count($taggingCollection) > 1;
             $entry['backgroundColor'] = $tag->getBackgroundColor();
 
             $result[] = $entry;


### PR DESCRIPTION
Hi, guys 
While loading a entity page with tags, the following code is executed https://github.com/orocrm/platform/blob/2.2/src/Oro/Bundle/TagBundle/Entity/TagManager.php#L290-L297. If we have 2MM entities and only one single tag for each, the 2MM objects(Tagging) will create during load a page.

*STR*
1) Create 2M entities record
2) Create a one tag
3) Add this tag for each entity
4) Go to view entity page

**Actual**
While load a page process uses  ~2GB RAM of memory