### PR TITLE
BusinessUnitTreeTransformer. Fix error while save empty value 

### DIFF
--- a/src/Oro/Bundle/OrganizationBundle/Form/Transformer/BusinessUnitTreeTransformer.php
+++ b/src/Oro/Bundle/OrganizationBundle/Form/Transformer/BusinessUnitTreeTransformer.php
@@ -26,7 +26,7 @@ class BusinessUnitTreeTransformer implements DataTransformerInterface
     public function reverseTransform($value)
     {
         if (null === $value) {
-            return 0;
+            return null;
         } elseif (is_array($value)) {
             foreach ($value as &$val) {
                 if ($val === '') {


### PR DESCRIPTION
The next error occurred while save entity that have "owner_type"="BUSINESS_UNIT" without prefilled businiessUnit attribute
![selection_074](https://user-images.githubusercontent.com/21358010/28823568-d645190e-76c6-11e7-9630-543f2d170331.png)
