### PR TITLE
[DX] Added implicit timeout option to "oro:install" command

### DIFF
--- a/src/Oro/Bundle/InstallerBundle/Command/InstallCommand.php
+++ b/src/Oro/Bundle/InstallerBundle/Command/InstallCommand.php
@@ -78,7 +78,7 @@ class InstallCommand extends AbstractCommand implements InstallCommandInterface
                 null,
                 InputOption::VALUE_NONE,
                 'Timeout for "oro:migration:load" command, use 0 for no timeout'
-            );;
+            );
 
         parent::configure();
     }

--- a/src/Oro/Bundle/InstallerBundle/Command/InstallCommand.php
+++ b/src/Oro/Bundle/InstallerBundle/Command/InstallCommand.php
@@ -73,7 +73,12 @@ class InstallCommand extends AbstractCommand implements InstallCommandInterface
                 null,
                 InputOption::VALUE_NONE,
                 'Determines whether translation data need to be downloaded or not'
-            );
+            )->addOption(
+                'timeout',
+                null,
+                InputOption::VALUE_NONE,
+                'Timeout for "oro:migration:load" command, use 0 for no timeout'
+            );;
 
         parent::configure();
     }


### PR DESCRIPTION
Hello,

there is NO installation possible without set a timeout (big) value or - most of the time - by setting no timeout.

As a beginner, I've spent useless time retrieving this option that should be documented even if it's not an explicit command option.

Pros:
* description of the option, advice about `0` value

Cons:
* none?

What do you think?