### PR TITLE
Fix execution of js-scripts on inline embedded forms

### DIFF
--- a/src/Oro/Bundle/EmbeddedFormBundle/Resources/public/js/embed.form.js
+++ b/src/Oro/Bundle/EmbeddedFormBundle/Resources/public/js/embed.form.js
@@ -73,8 +73,12 @@ var ORO = (function(ORO) {
             var scripts = this.container.querySelectorAll('script');
             if (scripts.length > 0) {
                 var scriptsFragment = document.createDocumentFragment();
-                var realTag = null;
-                for (var k in scripts) if (scripts.hasOwnProperty(k)) {
+                var realTag;
+                for (var k in scripts) {
+                    if (!scripts.hasOwnProperty(k)) {
+                        continue;
+                    }
+                    
                     realTag = document.createElement('script');
 
                     if (scripts[k].hasAttribute('src')) {

--- a/src/Oro/Bundle/EmbeddedFormBundle/Resources/public/js/embed.form.js
+++ b/src/Oro/Bundle/EmbeddedFormBundle/Resources/public/js/embed.form.js
@@ -69,6 +69,25 @@ var ORO = (function(ORO) {
             if (form) {
                 form.addEventListener('submit', this.onSubmit.bind(this));
             }
+
+            var scripts = this.container.querySelectorAll('script');
+            if (scripts.length > 0) {
+                var scriptsFragment = document.createDocumentFragment();
+                var realTag = null;
+                for (var k in scripts) if (scripts.hasOwnProperty(k)) {
+                    realTag = document.createElement('script');
+
+                    if (scripts[k].hasAttribute('src')) {
+                        realTag.setAttribute('src', scripts[k].getAttribute('src'));
+                    } else {
+                        realTag.innerHTML = scripts[k].innerHTML;
+                    }
+
+                    scripts[k].parentNode.removeChild(scripts[k]);
+                    scriptsFragment.appendChild(realTag);
+                }
+                this.container.appendChild(scriptsFragment);
+            }
         },
 
         onSubmit: function(e) {


### PR DESCRIPTION
One of option of embed of [EmbeddedForm](https://github.com/oroinc/platform/tree/2.3/src/Oro/Bundle/EmbeddedFormBundle) is `inline`.

If a view of form type or a view of layout have some javascript, it isn't executing, because a browser don't know what code is javascript.

The PR fixes it.

Thanks!