### PR TITLE
Fix error when adding order by virtual field on segment

### DIFF
--- a/src/Oro/Bundle/SegmentBundle/Query/SegmentQueryConverter.php
+++ b/src/Oro/Bundle/SegmentBundle/Query/SegmentQueryConverter.php
@@ -165,8 +165,24 @@ class SegmentQueryConverter extends GroupingOrmQueryConverter
         if ($this->columnAliases && $columnAlias) {
             $columnNames = array_flip($this->columnAliases);
             $columnName = $columnNames[$columnAlias];
-            $prefixedColumnName = $this->getTableAliasForColumn($columnName) . '.' . $columnName;
+            $prefixedColumnName = $this->getPrefixedColumnName($columnName);
             $this->qb->addOrderBy($prefixedColumnName, $columnSorting);
         }
+    }
+
+    /**
+     * @param string $columnName
+     * @return string
+     */
+    protected function getPrefixedColumnName($columnName)
+    {
+        $joinId =  $this->joinIdHelper->buildColumnJoinIdentifier($columnName);
+        if (array_key_exists($joinId, $this->virtualColumnOptions)
+            && array_key_exists($columnName, $this->virtualColumnExpressions)
+        ) {
+            return $this->virtualColumnExpressions[$columnName];
+        }
+
+        return $this->getTableAliasForColumn($columnName) . '.' . $columnName;
     }
 }


### PR DESCRIPTION
When add order by virtual fields on segment we get following error
![selection_004](https://user-images.githubusercontent.com/21358010/31277751-20a645d2-aaab-11e7-8c66-e5a5c42d50d4.png)
```
Getting grid data failed.
Context: { "exception": "Exception(Doctrine\\ORM\\Query\\QueryException): [Semantical Error] line 0, col 255 near 'primaryEmail': Error: Class Oro\\Bundle\\ContactBundle\\Entity\\Contact has no field or association named primaryEmail" }
```