### PR TITLE
[Message queue] Enhancement performance for dbal driver

### DIFF
--- a/src/Oro/Bundle/MessageQueueBundle/Migrations/Schema/v1_7/OroMessageQueueBundle.php
+++ b/src/Oro/Bundle/MessageQueueBundle/Migrations/Schema/v1_7/OroMessageQueueBundle.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Oro\Bundle\OroMessageQueueBundle\Migrations\Schema\v1_7;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\PostgreSqlPlatform;
+use Doctrine\DBAL\Schema\Schema;
+
+use Oro\Bundle\MigrationBundle\Migration\ConnectionAwareInterface;
+use Oro\Bundle\MigrationBundle\Migration\Migration;
+use Oro\Bundle\MigrationBundle\Migration\QueryBag;
+
+class OroMessageQueueBundle implements Migration, ConnectionAwareInterface
+{
+    /** @var Connection */
+    protected $connection;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function up(Schema $schema, QueryBag $queries)
+    {
+        if (!$this->connection->getDatabasePlatform() instanceof PostgreSqlPlatform) {
+            return;
+        }
+
+        $table = $schema->getTable('oro_message_queue');
+        if (!$table->hasIndex('idx_oro_message_queue_pri_id')) {
+            $queries->addPostQuery(
+                'CREATE INDEX idx_oro_message_queue_pri_id on oro_message_queue (priority DESC, id ASC)'
+            );
+        }
+    }
+
+    /**
+     * Sets the database connection
+     *
+     * @param Connection $connection
+     */
+    public function setConnection(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+}

--- a/src/Oro/Component/MessageQueue/DependencyInjection/DbalTransportFactory.php
+++ b/src/Oro/Component/MessageQueue/DependencyInjection/DbalTransportFactory.php
@@ -43,6 +43,7 @@ class DbalTransportFactory implements TransportFactoryInterface
                     ->cannotBeEmpty()
                     ->end()
                 ->integerNode('polling_interval')->min(50)->defaultValue(1000)->cannotBeEmpty()->end()
+                ->integerNode('prefetch_size')->min(1)->defaultValue(1)->end()
         ;
     }
 
@@ -87,7 +88,10 @@ class DbalTransportFactory implements TransportFactoryInterface
             new Reference('doctrine'),
             $config['connection'],
             $config['table'],
-            ['polling_interval' => $config['polling_interval']]
+            [
+                'polling_interval' => $config['polling_interval'],
+                'prefetch_size' =>  $config['prefetch_size']
+            ]
         ]);
         $connectionId = sprintf('oro_message_queue.transport.%s.connection', $this->getName());
         $container->setDefinition($connectionId, $connection);

--- a/src/Oro/Component/MessageQueue/Transport/Dbal/DbalSession.php
+++ b/src/Oro/Component/MessageQueue/Transport/Dbal/DbalSession.php
@@ -64,8 +64,13 @@ class DbalSession implements SessionInterface
 
         $consumer = new DbalMessageConsumer($this, $destination);
 
-        if (isset($this->connection->getOptions()['polling_interval'])) {
-            $consumer->setPollingInterval($this->connection->getOptions()['polling_interval']);
+        $options = $this->connection->getOptions();
+        if (isset($options['polling_interval'])) {
+            $consumer->setPollingInterval($options['polling_interval']);
+        }
+
+        if (isset($options['prefetch_size'])) {
+            $consumer->setPrefetchSize($options['prefetch_size']);
         }
 
         return $consumer;


### PR DESCRIPTION
Hi, I noticed that speed of message processing significantly decreases with increasing queue size, after investigate I found of cause of problem I can suggest the following solution

In first: Index works slowly for pgsql on 100k message in queue, see explain 
```
Limit  (cost=23202.00..23202.02 rows=10 width=6) (actual time=122.237..122.238 rows=10 loops=1)
  ->  Sort  (cost=23202.00..23857.36 rows=262144 width=6) (actual time=122.236..122.237 rows=10 loops=1)
        Sort Key: priority DESC, id
        Sort Method: top-N heapsort  Memory: 25kB
        ->  Seq Scan on oro_message_queue  (cost=0.00..17537.16 rows=262144 width=6) (actual time=0.013..87.115 rows=262144 loops=1)
              Filter: ((consumer_id IS NULL) AND ((delayed_until IS NULL) OR (delayed_until <= 10000000)) AND ((queue)::text = 'oro.default'::text))
Planning time: 0.290 ms
Execution time: 122.275 ms
```
After adding index by two fields  `priority DESC, id ASC ` I get increase of performance  about 1000 times  
```
Limit  (cost=0.42..1.93 rows=10 width=6) (actual time=0.102..0.126 rows=10 loops=1)
  ->  Index Scan using ik_oro_message_queue_pi on oro_message_queue  (cost=0.42..39594.55 rows=262144 width=6) (actual time=0.100..0.121 rows=10 loops=1)
        Filter: ((consumer_id IS NULL) AND ((delayed_until IS NULL) OR (delayed_until <= 10000000)) AND ((queue)::text = 'oro.default'::text))
Planning time: 0.538 ms
Execution time: 0.177 ms
```
Prefetch message to reduce the number of requests and locks to the database. 

**Testing result on "NullMessageProcessor" with 4 consumers**

| Queue | W/O idx (pri DESC, id ASC) | W/O Prefetch (m/sec.) |  Prefetch x2 (m/sec.) | Prefetch x4 (m/sec.)| Prefetch x16 (m/sec.) |
|-----|:------:|:------:|:------:|:------:|:------:|
| 100k| 26  | 420  | 880 | 1200 | 1740 |
| 1MM | 3.2 | 370  | 780 | 1050 | 1590 |
| 30MM| N/A | 340  | 600 | 900  | 1360 |

*Note*  Prefetch x4 - the consumer will fetch 4 messages from the database at a time and puts them in memory
