### PR TITLE
Bugfix: Use `\DateTimeInterface` check when date object is passed

### DIFF
--- a/src/Oro/Bundle/LocaleBundle/Formatter/DateTimeFormatter.php
+++ b/src/Oro/Bundle/LocaleBundle/Formatter/DateTimeFormatter.php
@@ -255,9 +255,9 @@ class DateTimeFormatter
     /**
      * Returns DateTime by $data and $timezone and false otherwise
      *
-     * @param \DateTime|string|int $date
+     * @param \DateTimeInterface|string|int $date
      *
-     * @return \DateTime|false
+     * @return \DateTimeInterface|false
      */
     public function getDateTime($date)
     {
@@ -265,7 +265,7 @@ class DateTimeFormatter
             return false;
         }
 
-        if ($date instanceof \DateTime) {
+        if ($date instanceof \DateTimeInterface) {
             return $date;
         }
 


### PR DESCRIPTION
We are working with `\DateTimeInterface`, in particular with `\DateTimeImmutable` instances with Doctrine using Custom Type. Without this change, method `getDateTime()` treat our `\DateTimeImmutable` as integer and tries to pass it to `setTimestamp()` method which triggers an error.

With this update, it's possible ot use any instance of `\DateTimeInterface` interface.

Since this bundle requires PHP 7.0+, it's a safe update.

https://github.com/oroinc/platform/blob/a9b4905c85ddf2e3cebae5abc74bb9f8d6900d32/src/Oro/Bundle/LocaleBundle/composer.json#L9

No BC break.