### PR TITLE
Fix bad reference to $currentUser parameter

### DIFF
--- a/src/Oro/Bundle/OrganizationBundle/Entity/Manager/BusinessUnitManager.php
+++ b/src/Oro/Bundle/OrganizationBundle/Entity/Manager/BusinessUnitManager.php
@@ -170,7 +170,7 @@ class BusinessUnitManager
             return true;
         } elseif (AccessLevel::LOCAL_LEVEL === $accessLevel) {
             $businessUnits =  $treeProvider->getTree()->getUserBusinessUnitIds(
-                $this->$currentUser->getId(),
+                $currentUser->getId(),
                 $organization
             );
         } elseif (AccessLevel::DEEP_LEVEL === $accessLevel) {


### PR DESCRIPTION
$currentUser was being used as a dynamic variable name on $this. Needs to be referenced directly as a User object.