### PR TITLE
Allow users to create DISTINCT functions for aggregation SQL operators (COUNT, SUM, AVG) in Oro Reports

### DIFF
--- a/src/Oro/Bundle/ReportBundle/Resources/config/oro/query_designer.yml
+++ b/src/Oro/Bundle/ReportBundle/Resources/config/oro/query_designer.yml
@@ -1,5 +1,22 @@
 query_designer:
     aggregates:
+        identifier_distinct:
+            applicable: [{identifier: true}]
+            functions:
+                - { name: Count Distinct, expr: COUNT(DISTINCT $column), return_type: integer }
+            query_type: [report]
+        number_distinct:
+            applicable: [{type: integer}, {type: smallint}, {type: bigint}, {type: decimal}, {type: float}, {type: money}, {type: percent}]
+            functions:
+                - { name: Count Distinct, expr: COUNT(DISTINCT $column), return_type: integer }
+                - { name: Sum Distinct,   expr: SUM(DISTINCT $column) }
+                - { name: Avg Distinct,   expr: AVG(DISTINCT $column) }
+            query_type: [report]
+        other_distinct:
+            applicable: [{type: string}, {type: text}, {type: date}, {type: datetime}]
+            functions:
+                - { name: Count Distinct, expr: COUNT(DISTINCT $column), return_type: integer }
+            query_type: [report]
         identifier:
             applicable: [{identifier: true}]
             functions:

--- a/src/Oro/Bundle/ReportBundle/Resources/translations/messages.en.yml
+++ b/src/Oro/Bundle/ReportBundle/Resources/translations/messages.en.yml
@@ -1,6 +1,24 @@
 oro:
     query_designer:
         aggregates:
+            identifier_distinct:
+                Count Distinct:
+                    name: Count Distinct
+                    hint: Number of unique items
+            number_distinct:
+                Count Distinct:
+                    name: Count Distinct
+                    hint: Number of unique items
+                Sum Distinct:
+                    name: Sum Distinct
+                    hint: Sum of all unique values
+                Avg Distinct:
+                    name: Average Distinct
+                    hint: Average of unique values
+            other_distinct:
+                Count Distinct:
+                    name: Count Distinct
+                    hint: Number of unique items
             identifier:
                 Count:
                     name: Count


### PR DESCRIPTION
Allow users to create DISTINCT functions for aggregation SQL operators (COUNT, SUM, AVG) in Oro Reports. 

It's a very simple pull request, that adds a very great feature for all community that create simple and advanced reports in Oro.

It's deeply based on this question in OroCRM Forum: https://oroinc.com/orocrm/forums/topic/create-custom-function-in-orocrm-reports

Closes #825