### PR TITLE
EntityExtendBundle: add ORM reflection method

### DIFF
--- a/src/Oro/Bundle/EntityExtendBundle/Migration/EntityMetadataHelper.php
+++ b/src/Oro/Bundle/EntityExtendBundle/Migration/EntityMetadataHelper.php
@@ -102,6 +102,23 @@ class EntityMetadataHelper
     }
 
     /**
+     * Gets an entity table column name by entity name and field name
+     *
+     * @param string $className
+     * @param string $fieldName
+     * @return string|null
+     */
+    public function getColumnNameByFieldName($className, $fieldName)
+    {
+        $manager = $this->doctrine->getManagerForClass($className);
+        if ($manager instanceof EntityManager) {
+            return $manager->getClassMetadata($className)->getColumnName($fieldName);
+        }
+
+        return null;
+    }
+
+    /**
      * Adds a mapping between a table name and entity class name.
      * This method can be used for new entities without doctrine mapping created during
      * loading migrations, for instance for custom entities.

--- a/src/Oro/Bundle/EntityExtendBundle/Migration/Extension/ExtendExtension.php
+++ b/src/Oro/Bundle/EntityExtendBundle/Migration/Extension/ExtendExtension.php
@@ -905,6 +905,19 @@ class ExtendExtension implements NameGeneratorAwareInterface
     }
 
     /**
+     * Gets a field name by a table name and a column name
+     *
+     * @param string $className
+     * @param string $fieldName
+     *
+     * @return string|null
+     */
+    public function getColumnNameByFieldName($className, $fieldName)
+    {
+        return $this->entityMetadataHelper->getColumnNameByFieldName($className, $fieldName);
+    }
+
+    /**
      * @param Table|string $table A Table object or table name
      *
      * @return string


### PR DESCRIPTION
Added a way to get the column name from the class name and field name. When using enums and loads of EntityExtend migrations, it is not easy to find out the column name