### PR TITLE
Show correct labels in dataaudit widget

### DIFF
--- a/src/Oro/Bundle/DataAuditBundle/Resources/views/macros.html.twig
+++ b/src/Oro/Bundle/DataAuditBundle/Resources/views/macros.html.twig
@@ -29,9 +29,9 @@
 {% macro renderFieldName(objectClass, fieldKey, fieldValue) %}
     {% set fieldLabel = oro_field_config_value(objectClass, fieldKey, 'label')|default(fieldKey) %}
     {% if fieldValue.translationDomain is defined %}
-        {% set fieldLabel = fieldKey|trans({}, fieldValue.translationDomain) %}
+        {% set fieldLabel = fieldLabel|trans({}, fieldValue.translationDomain) %}
     {% else %}
-        {% set fieldLabel = fieldKey|trans %}
+        {% set fieldLabel = fieldLabel|trans %}
     {% endif %}
     {{- fieldLabel -}}:
 {% endmacro %}


### PR DESCRIPTION
Hey guys!

i discovered a "bug" in the data audit widget. Currently the data audit widget shows only the name of the property which has been changed. But it seems that only the wrong key is passed to the translator.

I checked this in two projects. The variable `fieldKey` is e.g "name" not "vendor.entity.name" so the validator can't resolve this.