### PR TITLE
Fix execution of js-scripts on inline embedded forms 2

### DIFF
--- a/src/Oro/Bundle/EmbeddedFormBundle/Resources/public/js/embed.form.js
+++ b/src/Oro/Bundle/EmbeddedFormBundle/Resources/public/js/embed.form.js
@@ -79,7 +79,8 @@ var ORO = (function(ORO) {
                     realTag = document.createElement('script');
 
                     if (scripts[k].hasAttribute('src')) {
-                        realTag.setAttribute('src', scripts[k].getAttribute('src'));
+                        realTag.async = scripts[k].async;
+                        realTag.src = scripts[k].src;
                     } else {
                         realTag.innerHTML = scripts[k].innerHTML;
                     }


### PR DESCRIPTION
Additional fixes for #752.
By default the browser for `document.createElement('script')` loads the JavaScript asynchronously, in this PR was fix inherit of `async` 