### PR TITLE
add ability to remove ManyToMany enum field in migrations

### DIFF
--- a/src/Oro/Bundle/EntityConfigBundle/Migration/RemoveEnumFieldQuery.php
+++ b/src/Oro/Bundle/EntityConfigBundle/Migration/RemoveEnumFieldQuery.php
@@ -6,7 +6,7 @@ use Doctrine\DBAL\Types\Type;
 use Oro\Bundle\MigrationBundle\Migration\ParametrizedMigrationQuery;
 use Psr\Log\LoggerInterface;
 
-class RemoveEnumFieldQuery extends ParametrizedMigrationQuery
+abstract class RemoveEnumFieldQuery extends ParametrizedMigrationQuery
 {
     /** @var string  */
     protected $entityClass = '';
@@ -97,8 +97,9 @@ class RemoveEnumFieldQuery extends ParametrizedMigrationQuery
     protected function updateEntityData(LoggerInterface $logger, $enumClass, $data)
     {
         $data = $data ? $this->connection->convertToPHPValue($data, Type::TARRAY) : [];
+        $relationType = $this->getRelationType();
 
-        $extendKey = sprintf('manyToOne|%s|%s|%s', $this->entityClass, $enumClass, $this->enumField);
+        $extendKey = sprintf($relationType . '|%s|%s|%s', $this->entityClass, $enumClass, $this->enumField);
         if (isset($data['extend']['relation'][$extendKey])) {
             unset($data['extend']['relation'][$extendKey]);
         }
@@ -135,4 +136,10 @@ class RemoveEnumFieldQuery extends ParametrizedMigrationQuery
     {
         return 'Remove outdated '. $this->enumField .' enum field data';
     }
+
+    /**
+     * Returns the type of the relation, for example manyToMany, or manyToOne
+     * @return string
+     */
+    abstract public function getRelationType();
 }

--- a/src/Oro/Bundle/EntityConfigBundle/Migration/RemoveManyToManyEnumFieldQuery.php
+++ b/src/Oro/Bundle/EntityConfigBundle/Migration/RemoveManyToManyEnumFieldQuery.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Oro\Bundle\EntityConfigBundle\Migration;
+
+use Oro\Bundle\EntityExtendBundle\Extend\RelationType;
+
+class RemoveManyToManyEnumFieldQuery extends RemoveEnumFieldQuery
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getRelationType()
+    {
+        return RelationType::MANY_TO_MANY;
+    }
+}

--- a/src/Oro/Bundle/EntityConfigBundle/Migration/RemoveManyToOneEnumFieldQuery.php
+++ b/src/Oro/Bundle/EntityConfigBundle/Migration/RemoveManyToOneEnumFieldQuery.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Oro\Bundle\EntityConfigBundle\Migration;
+
+use Oro\Bundle\EntityExtendBundle\Extend\RelationType;
+
+class RemoveManyToOneEnumFieldQuery extends RemoveEnumFieldQuery
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getRelationType()
+    {
+        return RelationType::MANY_TO_ONE;
+    }
+}


### PR DESCRIPTION
(bug #773)

**Description**
Added ability to remove ManyToMany enums in migrations. 
Before it 'manyToOne' was [hardcoded](https://github.com/oroinc/platform/blob/master/src/Oro/Bundle/EntityConfigBundle/Migration/RemoveEnumFieldQuery.php#L101) and was not possible to change. Now can use RemoveManyToManyEnumFieldQuery or RemoveManyToOneEnumFieldQuery

Signed-off-by: Morozov Alexander <webdevelopacc@gmail.com>