### PR TITLE
Fix error thrown with has_more data array

### DIFF
--- a/src/Oro/Bundle/ApiBundle/Request/Rest/RestDocumentBuilder.php
+++ b/src/Oro/Bundle/ApiBundle/Request/Rest/RestDocumentBuilder.php
@@ -56,7 +56,7 @@ class RestDocumentBuilder extends AbstractDocumentBuilder
     ): array {
         $result = [];
         foreach ($collection as $object) {
-            $result[] = null === $object || \is_scalar($object)
+            $result[] = null === $object || \is_scalar($object) || \is_array($object)
                 ? $object
                 : $this->convertObjectToArray($object, $requestType, $metadata);
         }


### PR DESCRIPTION
TL;DR; The \is_scalar does not deal with the has_more property array and throws an exception when working with collections.  Adding \is_array fixes this problem.

Ran into problems trying to use the Oro Platform API on version 3.1.  The api would work just fine using the sandbox URL http://localhost/api/doc/rest_json_api#get--api-users but when hit from a 3rd party application or curl with WSSE the api would fail.  The api result would come back as 500 with the following response:
[{"title":"runtime exception","detail":"An object of the type \"Oro\\Bundle\\UserBundle\\Entity\\User\" does not have the identifier property \"id\"."}]

This ended up coming from /oro/platform/src/Oro/Bundle/ApiBundle/Request/DocumentBuilder/EntityIdAccessor.php.  Logging the data being passed I found that after it had processed the list of User entities the data object array ('has_more' => true) was being passed down into this function when it expected an Entity object.  Tracing this up the call stack the problems is the use of the \is_scalar($object) property which does not detect the array type.  Adding the \is_array($object) fixes the problem and now the collections are being returned properly.

This is my first time contributing to this project and I don't see any Contributing.md on the best practice to push changes upstream.  If there's more detail or information that's needed for the pull request let me know and I'll adjust it.