### PR TITLE
Datagrid filters missing after deleting an entity

### DIFF
--- a/src/Oro/Bundle/UIBundle/Resources/views/macros.html.twig
+++ b/src/Oro/Bundle/UIBundle/Resources/views/macros.html.twig
@@ -566,7 +566,7 @@
         {% set linkParams = linkParams|merge({ 'data': data }) %}
     {% endif %}
     {% if parameters.dataRedirect is defined %}
-        {% set data = linkParams.data|merge({'redirect': parameters.dataRedirect}) %}
+        {% set data = linkParams.data|merge({'redirect': oro_url_add_query(parameters.dataRedirect)}) %}
         {% set linkParams = linkParams|merge({ 'data': data }) %}
     {% endif %}
     {% if parameters.data is defined %}


### PR DESCRIPTION
When using any filter on datagrid and then going to detail view of any record and deleting it they are redirected back to datagrid view but filters are lost. 