### PR TITLE
[MessageQueue] Allow all callables not only closures

### DIFF
--- a/src/Oro/Component/MessageQueue/Job/JobRunner.php
+++ b/src/Oro/Component/MessageQueue/Job/JobRunner.php
@@ -40,7 +40,7 @@ class JobRunner
      *
      * @return mixed
      */
-    public function runUnique($ownerId, $name, \Closure $runCallback)
+    public function runUnique($ownerId, $name, callable $runCallback)
     {
         $rootJob = $this->jobProcessor->findOrCreateRootJob($ownerId, $name, true);
         if (!$rootJob) {
@@ -82,7 +82,7 @@ class JobRunner
      *
      * @return mixed
      */
-    public function createDelayed($name, \Closure $startCallback)
+    public function createDelayed($name, callable $startCallback)
     {
         $childJob = $this->jobProcessor->findOrCreateChildJob($name, $this->rootJob);
 
@@ -115,7 +115,7 @@ class JobRunner
      *
      * @throws \Exception
      */
-    public function runDelayed($jobId, \Closure $runCallback)
+    public function runDelayed($jobId, callable $runCallback)
     {
         $job = $this->jobProcessor->findJobById($jobId);
         if (! $job) {

--- a/src/Oro/Component/MessageQueue/Job/JobRunner.php
+++ b/src/Oro/Component/MessageQueue/Job/JobRunner.php
@@ -36,7 +36,7 @@ class JobRunner
     /**
      * @param string $ownerId
      * @param string $name
-     * @param \Closure $runCallback
+     * @param callable $runCallback
      *
      * @return mixed
      */
@@ -78,7 +78,7 @@ class JobRunner
 
     /**
      * @param string   $name
-     * @param \Closure $startCallback
+     * @param callable $startCallback
      *
      * @return mixed
      */
@@ -109,7 +109,7 @@ class JobRunner
 
     /**
      * @param string   $jobId
-     * @param \Closure $runCallback
+     * @param callable $runCallback
      *
      * @return mixed
      *


### PR DESCRIPTION
Hey!

the job runner does actually only supports `Closures` instead of any `callable`. Closures are generally bad to (unit)test. So i try to avoid to use this pattern.

PHP does support the `callable` typehint which provides a lot more flexibility.