### PR TITLE
Fixed "Deprecation warning: require.nesbot/Carbon is invalid"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "lexik/maintenance-bundle": "2.1.5",
         "composer/composer": "1.6.*",
         "akeneo/batch-bundle": "0.4.*",
-        "nesbot/Carbon": "1.29.*",
+        "nesbot/carbon": "1.29.*",
         "monolog/monolog": "1.23.*",
         "ocramius/proxy-manager": "2.1.1",
         "knplabs/knp-gaufrette-bundle": "0.3.*",


### PR DESCRIPTION
Fixed "Deprecation warning: require.nesbot/Carbon is invalid, it should not contain uppercase characters. Please use nesbot/carbon instead. Make sure you fix this as Composer 2.0 will error."