### PR TITLE
Speed up uniqid() calls by using more entropy

### DIFF
--- a/src/Oro/Bundle/FormBundle/Form/Extension/AdditionalAttrExtension.php
+++ b/src/Oro/Bundle/FormBundle/Form/Extension/AdditionalAttrExtension.php
@@ -28,7 +28,7 @@ class AdditionalAttrExtension extends AbstractTypeExtension
         if (!empty($options['random_id']) && isset($view->vars['id'])) {
             $view->vars['attr'] = isset($view->vars['attr']) ? $view->vars['attr'] : [];
             $view->vars['attr']['data-ftid'] = $view->vars['id'];
-            $view->vars['id'] .= uniqid('-uid-');
+            $view->vars['id'] .= uniqid('-uid-', true);
         }
         if (isset($view->vars['name'])) {
             $fieldPrefix = $view->parent ? 'field__' : 'form__';


### PR DESCRIPTION
While profiling our application I noticed about 200 calls to `uniqid()`, most of these originating from `\Oro\Bundle\FormBundle\Form\Extension\AdditionalAttrExtension::finishView`. All these combined calls take almost 300ms (total page load is 3.6s) on my vagrant box.

![image](https://user-images.githubusercontent.com/1918518/54028314-eab9d500-41a4-11e9-83cd-98f42c3b1693.png)

After a quick google search I ended up on [this blog post](https://blog.kevingomez.fr/til/2015/07/26/why-is-uniqid-slow/) explaining why it's slow. Turns out `uniqid()` is using `usleep(1)` to be more random. By using the `$more_entropy` option you eliminate this delay.

This PR removes about 300ms off my request time. The ID generated does change format-wise:

```
php > echo uniqid('-uid-');
-uid-5c825c234b227
php > echo uniqid('-uid-', true);
-uid-5c825c252f64b1.62107365
```

Whether that's acceptable is up to you, I'm not very experienced with Oro.