### PR TITLE
Add Webpack Progress flag to assets:build command

### DIFF
--- a/src/Oro/Bundle/AssetBundle/Command/OroAssetsBuildCommand.php
+++ b/src/Oro/Bundle/AssetBundle/Command/OroAssetsBuildCommand.php
@@ -100,6 +100,12 @@ DESCRIPTION
                 webpack continues to watch the changes in any of the resolved files.'
             )
             ->addOption(
+                'progress',
+                'p',
+                InputOption::VALUE_NONE,
+                'Show build progress as a percentage in output (verbose mode).'
+            )
+            ->addOption(
                 'npm-install',
                 'i',
                 InputOption::VALUE_NONE,
@@ -107,7 +113,8 @@ DESCRIPTION
                 'Required when "node_modules" folder is corrupted.'
             )
             ->addUsage('admin.oro --watch')
-            ->addUsage('blank -w')
+            ->addUsage('--progress')
+            ->addUsage('blank -w -p')
             ->addUsage('default')
             ->addUsage('-i');
     }
@@ -153,6 +160,9 @@ DESCRIPTION
         }
         if ($input->getOption('watch')) {
             $command[] = '--watch';
+        }
+        if ($input->getOption('progress')) {
+            $command[] = '--progress';
         }
         $command[] = '--env.symfony='.$input->getOption('env');
         $command[] = '--colors';


### PR DESCRIPTION
When using `php bin/console oro:assets:build --watch`, when files are modified nothing is displayed in the terminal output (even though the builds are running successfully). This makes it difficult to tell if Webpack has detected your code changes, or if it's actually building the assets.

Webpack has a handy `--progress` CLI parameter to watch the progress of builds:
https://webpack.js.org/api/cli/#debug-options

Adding the `--progress` parameter allows you to see a progress percentage, along with the filename currently being built.
The output looks something like this:
```
[122] ./css/layout/basetheme/styles.js 28 bytes {11} [built]
+ 221 hidden modules
65% building 220/228 modules 8 active ...public/css/layout/blank/styles.css.scss 
```

This Pull Request adds `--progress` as an optional flag, including usage instructions.

Another possible future enhancement could be to allow passing additional flags to the Webpack CLI, something like:
```
php bin/console oro:assets:install --watch --webpack-opts='--debug --verbose --bail --cache=false'
```

This would allow devs fine-grained control over the way the build runs, which can be important in CI environments.