### PR TITLE
Add empty/not empty to dictionary conditions in segment/report

### DIFF
--- a/src/Oro/Bundle/FilterBundle/Filter/BaseMultiChoiceFilter.php
+++ b/src/Oro/Bundle/FilterBundle/Filter/BaseMultiChoiceFilter.php
@@ -107,6 +107,10 @@ abstract class BaseMultiChoiceFilter extends AbstractFilter
                 return $ds->expr()->eq($fieldName, $parameterName, true);
             case DictionaryFilterType::NOT_EQUAL:
                 return $ds->expr()->neq($fieldName, $parameterName, true);
+            case FilterUtility::TYPE_NOT_EMPTY:
+                return $ds->expr()->isNotNull($fieldName);
+            case FilterUtility::TYPE_EMPTY:
+                return $ds->expr()->isNull($fieldName);
             default:
                 return $ds->expr()->in($fieldName, $parameterName, true);
         }

--- a/src/Oro/Bundle/FilterBundle/Form/Type/Filter/DictionaryFilterType.php
+++ b/src/Oro/Bundle/FilterBundle/Form/Type/Filter/DictionaryFilterType.php
@@ -2,6 +2,7 @@
 
 namespace Oro\Bundle\FilterBundle\Form\Type\Filter;
 
+use Oro\Bundle\FilterBundle\Filter\FilterUtility;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -11,6 +12,9 @@ use Symfony\Component\Form\FormView;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Translation\TranslatorInterface;
 
+/**
+ * Form type for dictionary filters.
+ */
 class DictionaryFilterType extends AbstractType
 {
     const NAME = 'oro_type_dictionary_filter';
@@ -113,6 +117,8 @@ class DictionaryFilterType extends AbstractType
                 'operator_choices' => [
                     $this->translator->trans('oro.filter.form.label_type_in') => self::TYPE_IN,
                     $this->translator->trans('oro.filter.form.label_type_not_in') => self::TYPE_NOT_IN,
+                    $this->translator->trans('oro.filter.form.label_type_empty') =>  FilterUtility::TYPE_EMPTY,
+                    $this->translator->trans('oro.filter.form.label_type_not_empty') => FilterUtility::TYPE_NOT_EMPTY,
                 ],
             ]
         )->setRequired(

--- a/src/Oro/Bundle/FilterBundle/Resources/public/js/filter/dictionary-filter.js
+++ b/src/Oro/Bundle/FilterBundle/Resources/public/js/filter/dictionary-filter.js
@@ -55,7 +55,8 @@ define(function(require) {
          * @property
          */
         criteriaValueSelectors: {
-            type: 'input[type="hidden"]:last'
+            type: 'input[type="hidden"]:last',
+            value: '.select-values-autocomplete'
         },
 
         filterParams: null,
@@ -155,7 +156,7 @@ define(function(require) {
                         }
                     ),
                     data: {
-                        keys: this.value.value
+                        keys: !this.isEmptyType(this.value.type) ? this.value.value : []
                     },
                     success: function(response) {
                         $container.removeClass('loading');
@@ -187,6 +188,7 @@ define(function(require) {
             this._writeDOMValue(this.value);
             this.applySelect2();
             this._updateCriteriaHint();
+            this._updateDOMValue();
             this.renderDeferred.resolve();
             this.trigger('update');
         },
@@ -238,7 +240,7 @@ define(function(require) {
             var selectedChoiceLabel = '';
             if (!_.isEmpty(this.choices)) {
                 var foundChoice = _.find(this.choices, function(choice) {
-                    return (parseInt(choice.value) === parseInt(value.type));
+                    return (parseInt(choice.value) === parseInt(value.type) || value.type === choice.value);
                 });
                 selectedChoiceLabel = foundChoice.label;
             }
@@ -359,6 +361,9 @@ define(function(require) {
          * @inheritDoc
          */
         isEmptyValue: function() {
+            if (this.isEmptyType(this.value.type)) {
+                return false;
+            }
             var value = this.getValue();
 
             return !value.value || value.value.length === 0;
@@ -402,7 +407,7 @@ define(function(require) {
             this.$(this.elementSelector).inputWidget('data', this.getDataForSelect2());
             this._updateDOMValue();
 
-            if (this.valueIsLoaded(value.value)) {
+            if (this.valueIsLoaded(value.value) || this.isEmptyType(value.type)) {
                 this._onValueUpdated(this.value, oldValue);
             } else {
                 this.loadValuesById('updateCriteriaLabels');


### PR DESCRIPTION
The PR to be able to use "is empty" and "is not empty" conditions when using dictionary filter in reports or segment. Currently only "is any of" and "is not any of" is available.
![Selection_999(210)](https://user-images.githubusercontent.com/21358010/55406746-640ad480-5565-11e9-9ee0-3f6b0d1481d8.png)
