### PR TITLE
Fix integration update template - for saving integration data while create new channel

### DIFF
--- a/src/Oro/Bundle/IntegrationBundle/Resources/views/Integration/update.html.twig
+++ b/src/Oro/Bundle/IntegrationBundle/Resources/views/Integration/update.html.twig
@@ -4,7 +4,10 @@
 {% form_theme form with oro_integration_themes(form) %}
 
 {% set entity = entity is defined ? entity : form.vars.value %}
-{% set formAction = entity.id ? path('oro_integration_update', { id: entity.id }) : path('oro_integration_create') %}
+{% set formAction = formAction is defined
+    ? formAction
+    : (entity.id ? path('oro_integration_update', { id: entity.id }) : path('oro_integration_create'))
+%}
 
 {% if entity.id %}
     {% oro_title_set({params : {"%integration.name%": entity.name } }) %}


### PR DESCRIPTION
After update orocrm from 2.6 to 3.1.4 - while create new or update integration channel (example magento channel) `index.php/channel/create/` after submit integration data in popup - error occurs:
<img width="1848" alt="Снимок экрана 2019-04-04 в 12 57 31" src="https://user-images.githubusercontent.com/16347791/55547159-5ece9680-56d9-11e9-9801-e13f21b86f72.png">
because not correct form action in popup.
Correct action must be `index.php/channel/integration/update/{id}` - template `OroIntegrationBundle:Integration:update.html.twig` extended `OroChannelBundle:ChannelIntegration:update.html.twig` and this template passes own action but `OroIntegrationBundle:Integration:update.html.twig` rewrite by default and actual action becomes `index.php/integration/update/{id}` 