### PR TITLE
Fix the oro:migration:dump command for unprefixed bundles

### DIFF
--- a/src/Oro/Bundle/MigrationBundle/Command/DumpMigrationsCommand.php
+++ b/src/Oro/Bundle/MigrationBundle/Command/DumpMigrationsCommand.php
@@ -102,7 +102,7 @@ class DumpMigrationsCommand extends ContainerAwareCommand
                     sprintf('Bundle "%s" is not a known bundle', $bundle)
                 );
             }
-            $this->namespace = str_replace($bundle, 'Entity', $bundles[$bundle]);
+            $this->namespace = substr($bundles[$bundle], 0, strrpos($bundles[$bundle], '\\')) . '\\Entity';
             $this->className = $bundle . 'Installer';
         }
     }


### PR DESCRIPTION
When using unprefixed bundles, eg. `AppBundle`, the `namespace` property gets filled with the value `Entity\Entity` instead of `AppBundle\Entity`