### PR TITLE
Fix issue #923 Segment Filter: Multi-Select 'not-any-of' returns results from 'any-of'

### DIFF
--- a/src/Oro/Bundle/FilterBundle/Filter/MultiEnumFilter.php
+++ b/src/Oro/Bundle/FilterBundle/Filter/MultiEnumFilter.php
@@ -79,7 +79,7 @@ class MultiEnumFilter extends BaseMultiChoiceFilter
             $fieldName,
             $parameterName,
             $this->getName(),
-            in_array($comparisonType, [DictionaryFilterType::NOT_EQUAL, DictionaryFilterType::TYPE_NOT_IN], true)
+            in_array($comparisonType, [DictionaryFilterType::NOT_EQUAL, DictionaryFilterType::TYPE_NOT_IN], false)
         );
     }
 


### PR DESCRIPTION
Fix #923 

This PR fix the issue, BUT you should investigate WHY the `$comparaisonType` is no longer a number. I did not cast it directly since i have no idea if it can be something else than a number.

Merge with caution :) 