### PR TITLE
Fix param type in Message Queue DbalStateDriver

### DIFF
--- a/src/Oro/Bundle/MessageQueueBundle/Consumption/StateDriver/DbalStateDriver.php
+++ b/src/Oro/Bundle/MessageQueueBundle/Consumption/StateDriver/DbalStateDriver.php
@@ -106,7 +106,7 @@ class DbalStateDriver implements StateDriverInterface
         $this->getConnection()->executeUpdate(
             $querySQL,
             ['updatedAt' => $date, 'id' => $this->key, 'dateWithGap' => $dateWithGap],
-            ['updatedAt' => Type::DATETIME, 'id' => Type::INTEGER, 'dateWithGap' => Type::DATETIME]
+            ['updatedAt' => Type::DATETIME, 'id' => Type::STRING, 'dateWithGap' => Type::DATETIME]
         );
     }
 


### PR DESCRIPTION
Changes parameter type of id column to string in `\Oro\Bundle\MessageQueueBundle\Consumption\StateDriver\DbalStateDriver::saveChangeStateDateWithTimeGap` to prevent SQL error `Truncated incorrect DOUBLE value` when running the message queue consumer