### PR TITLE
Fix Travis tests for 3.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ branches:
     - /^\d+\.\d+$/
 
 php:
-    - 7.1.17
+    - 7.2
 
 cache:
   directories:
@@ -23,6 +23,6 @@ before_script:
 
 script:
   - ./vendor/bin/phpunit
-  - ./vendor/bin/phpcs ./src -p --encoding=utf-8 --extensions=php --standard=./build/phpcs.xml
+  - ./vendor/bin/phpcs ./src -p --encoding=utf-8 --extensions=php --standard=PSR2
   - ./vendor/bin/php-cs-fixer fix --dry-run --config=./build/.php_cs --path-mode=intersection ./src
   - if [[ $DIFF ]]; then ./vendor/bin/phpmd ${DIFF//$'\n'/,} text ./build/phpmd.xml --suffixes php; fi

--- a/composer.json
+++ b/composer.json
@@ -119,8 +119,11 @@
         "behat/mink-selenium2-driver": "1.*",
         "behat/symfony2-extension": "2.1.*",
         "nelmio/alice": "2.3.*",
-        "johnkary/phpunit-speedtrap": "1.0.*",
-        "mybuilder/phpunit-accelerator": "1.2.*",
+        "phpunit/phpunit": "6.5.*",
+        "johnkary/phpunit-speedtrap": "2.0.*",
+        "symfony/phpunit-bridge": "3.4.*",
+        "mybuilder/phpunit-accelerator": "2.*",
+        "friendsofphp/php-cs-fixer": "2.12.*",       
         "squizlabs/php_codesniffer": "3.3.*",
         "phpmd/phpmd": "2.6.*"
     },

--- a/src/Oro/Bundle/AttachmentBundle/Tests/Unit/Acl/Voter/FileVoterTest.php
+++ b/src/Oro/Bundle/AttachmentBundle/Tests/Unit/Acl/Voter/FileVoterTest.php
@@ -84,7 +84,7 @@ class FileVoterTest extends \PHPUnit\Framework\TestCase
     {
         $this->doctrineHelper
             ->method('getEntityClass')
-            ->willReturn(get_class($subject));
+            ->willReturn(is_object($subject) ? get_class($subject) : null);
 
         self::assertSame(
             $expectedResult,

--- a/src/Oro/Bundle/LayoutBundle/Tests/Unit/Layout/Extension/Generator/ExpressionConditionVisitorTest.php
+++ b/src/Oro/Bundle/LayoutBundle/Tests/Unit/Layout/Extension/Generator/ExpressionConditionVisitorTest.php
@@ -44,7 +44,7 @@ class ExpressionConditionVisitorTest extends \PHPUnit\Framework\TestCase
 
         $strategy = new DefaultGeneratorStrategy();
         $this->assertSame(
-<<<CLASS
+            <<<CLASS
 class LayoutUpdateClass implements \Oro\Component\Layout\IsApplicableLayoutUpdateInterface
 {
     public function updateLayout(\$layoutManipulator, \$item)

--- a/src/Oro/Component/Layout/Tests/Unit/Loader/Generator/ConfigLayoutUpdateGeneratorTest.php
+++ b/src/Oro/Component/Layout/Tests/Unit/Loader/Generator/ConfigLayoutUpdateGeneratorTest.php
@@ -110,7 +110,7 @@ class ConfigLayoutUpdateGeneratorTest extends \PHPUnit\Framework\TestCase
     public function testGenerate()
     {
         $this->assertSame(
-<<<CLASS
+            <<<CLASS
 <?php
 
 /**

--- a/src/Oro/Component/Layout/Tests/Unit/Loader/Generator/Extension/ImportLayoutUpdateVisitorTest.php
+++ b/src/Oro/Component/Layout/Tests/Unit/Loader/Generator/Extension/ImportLayoutUpdateVisitorTest.php
@@ -27,7 +27,7 @@ class ImportLayoutUpdateVisitorTest extends \PHPUnit\Framework\TestCase
         $phpClass->setMethod($method);
         $strategy = new DefaultGeneratorStrategy();
         $this->assertSame(
-<<<CLASS
+            <<<CLASS
 use Oro\Component\Layout\ImportLayoutManipulator;
 
 class ImportedLayoutUpdate implements \Oro\Component\Layout\LayoutUpdateImportInterface, \Oro\Component\Layout\IsApplicableLayoutUpdateInterface
@@ -72,7 +72,7 @@ class ImportedLayoutUpdate implements \Oro\Component\Layout\LayoutUpdateImportIn
 }
 CLASS
         ,
-        $strategy->generate($visitContext->getClass())
+            $strategy->generate($visitContext->getClass())
         );
     }
     //codingStandardsIgnoreEnd

--- a/src/Oro/Component/Layout/Tests/Unit/Loader/Generator/Extension/ImportsAwareLayoutUpdateVisitorTest.php
+++ b/src/Oro/Component/Layout/Tests/Unit/Loader/Generator/Extension/ImportsAwareLayoutUpdateVisitorTest.php
@@ -39,7 +39,7 @@ class ImportsAwareLayoutUpdateVisitorTest extends \PHPUnit\Framework\TestCase
         $phpClass->setMethod($method);
         $strategy = new DefaultGeneratorStrategy();
         $this->assertSame(
-<<<CLASS
+            <<<CLASS
 class LayoutUpdateWithImport implements \Oro\Component\Layout\ImportsAwareLayoutUpdateInterface
 {
     public function testMethod()
@@ -67,7 +67,7 @@ class LayoutUpdateWithImport implements \Oro\Component\Layout\ImportsAwareLayout
 }
 CLASS
         ,
-        $strategy->generate($visitContext->getClass())
+            $strategy->generate($visitContext->getClass())
         );
     }
     //codingStandardsIgnoreEnd

--- a/src/Oro/Component/Layout/Tests/Unit/Loader/Generator/PhpLayoutUpdateGeneratorTest.php
+++ b/src/Oro/Component/Layout/Tests/Unit/Loader/Generator/PhpLayoutUpdateGeneratorTest.php
@@ -33,7 +33,7 @@ class PhpLayoutUpdateGeneratorTest extends \PHPUnit\Framework\TestCase
         $data = new GeneratorData($code, 'testfilename.php');
 
         $this->assertSame(
-<<<CLASS
+            <<<CLASS
 <?php
 
 /**
@@ -68,7 +68,7 @@ CLASS
     public function testShouldCompileConditions()
     {
         $this->assertSame(
-<<<CLASS
+            <<<CLASS
 <?php
 
 class testClassName implements \Oro\Component\Layout\LayoutUpdateInterface

--- a/src/Oro/Component/Layout/Tests/Unit/Loader/Visitor/ElementDependentVisitorTest.php
+++ b/src/Oro/Component/Layout/Tests/Unit/Loader/Visitor/ElementDependentVisitorTest.php
@@ -22,7 +22,7 @@ class ElementDependentVisitorTest extends \PHPUnit\Framework\TestCase
 
         $strategy = new DefaultGeneratorStrategy();
         $this->assertSame(
-<<<CONTENT
+            <<<CONTENT
 class LayoutUpdateClass implements \Oro\Component\Layout\Loader\Generator\ElementDependentLayoutUpdateInterface
 {
     public function getElement()


### PR DESCRIPTION
Package was added in `master` but missing in `3.1`

Fixes error: 
Class "Symfony\Bridge\PhpUnit\SymfonyTestsListener" does not exist