### PR TITLE
OroCRMBundle depends on this bundle

### DIFF
--- a/src/Oro/Bundle/ReminderBundle/Resources/config/oro/bundles.yml
+++ b/src/Oro/Bundle/ReminderBundle/Resources/config/oro/bundles.yml
@@ -1,2 +1,2 @@
 bundles:
-    - { name: Oro\Bundle\ReminderBundle\OroReminderBundle, priority: 30 }
+    - { name: Oro\Bundle\ReminderBundle\OroReminderBundle, priority: 0 }


### PR DESCRIPTION
Have to change priority of this bundle because OROCRMBundle depends on it. Otherwise oro:install --env=test fails.