### PR TITLE
Dashboard manager fails to determine dasbhoard

### DIFF
--- a/src/Oro/Bundle/DashboardBundle/Model/Manager.php
+++ b/src/Oro/Bundle/DashboardBundle/Model/Manager.php
@@ -206,12 +206,17 @@ class Manager
     /**
      * Find active dashboard or default dashboard
      *
-     * @param User $user
+     * @param User|null $user
      *
      * @return DashboardModel|null
      */
-    public function findUserActiveOrDefaultDashboard(User $user)
+    public function findUserActiveOrDefaultDashboard(?User $user)
     {
+        // No user, no way to determine dashboard. Even findDefaultDashboard requires proper user token.
+        if ($user === null) {
+            return null;
+        }
+        
         $activeDashboard = $this->findUserActiveDashboard($user);
         return $activeDashboard ? $activeDashboard : $this->findDefaultDashboard();
     }


### PR DESCRIPTION
For functional tests there is no user, as there is no user this throws exception. With this patch functional tests might work.