### PR TITLE
Fix BC break introduced in BAP-18638

### DIFF
--- a/src/Oro/Bundle/AttachmentBundle/Acl/FileAccessControlChecker.php
+++ b/src/Oro/Bundle/AttachmentBundle/Acl/FileAccessControlChecker.php
@@ -38,6 +38,6 @@ class FileAccessControlChecker
             ->getFieldConfig('attachment', $parentEntityClass, $parentEntityFieldName);
 
 
-        return (bool) $config->get('acl_protected', false, true);
+        return (bool) $config->get('acl_protected', false, false);
     }
 }


### PR DESCRIPTION
Due to default true e.g. image filters don´t work anymore until migration to add this option is run, which represents a BC break. Even Orocommerce core had to implement such migration, which is not acceptable for PATCH release under Sematic versioning scheme https://github.com/oroinc/orocommerce/commit/4c98d4e78d33413db4e5c9e432223a9134353549#diff-d2c55e6814f8d028e983c63285cc62a7

Attachments without option acl_protected set should default to the same value as previously - to not protected (false).