### PR TITLE
WorflowEntityValidator allow object

### DIFF
--- a/src/Oro/Bundle/WorkflowBundle/Validator/Constraints/WorkflowEntityValidator.php
+++ b/src/Oro/Bundle/WorkflowBundle/Validator/Constraints/WorkflowEntityValidator.php
@@ -198,7 +198,9 @@ class WorkflowEntityValidator extends ConstraintValidator
     {
         $fieldValue = $this->propertyAccessor->getValue($object, $restriction['field']);
         if (is_object($fieldValue)) {
-            $fieldValue = $this->doctrineHelper->getSingleEntityIdentifier($fieldValue);
+            $fieldValue = $this->doctrineHelper->isManageableEntity($fieldValue) ?
+                $this->doctrineHelper->getSingleEntityIdentifier($fieldValue) :
+                (string)$fieldValue;
         }
 
         if ($restriction['mode'] === 'allow') {


### PR DESCRIPTION
If entity contains some object rather than entity and it goes to validator it throws not manageable error. We have lots of DataTypes in our code. This is just an unnecessary restriction.