### PR TITLE
ORO CRM shows duplicated activities

### DIFF
--- a/src/Oro/Bundle/ActivityListBundle/Provider/ActivityListChainProvider.php
+++ b/src/Oro/Bundle/ActivityListBundle/Provider/ActivityListChainProvider.php
@@ -455,6 +455,10 @@ class ActivityListChainProvider
                 $list->setRelatedActivityId($this->doctrineHelper->getSingleEntityIdentifier($entity));
                 $list->setOrganization($provider->getOrganization($entity));
             }
+            
+            foreach ($provider->getActivityOwners() as $activityOwner) {
+                $list->addActivityOwner($activityOwner);
+            }
 
             $targets = $provider->getTargetEntities($entity);
             foreach ($targets as $target) {


### PR DESCRIPTION
Activity owners is being set after flush and this triggers Note entity update, and then ORO shows original note and duplicate with message that it has been updated by Admin. In the end having 2 duplicate notes, this might not be a best solution, as src/Oro/Bundle/ActivityListBundle/EventListener/ActivityListListener.php should only be triggered by UI accesable changes, but this listener itself modifies Entity and then triggers update event and in the end duplicate notes popup on the screen. Same goes for all activities.
This change will set ActivityOwners at the creation and wont be triggered by ActivityListener and in the end wont show "updated" duplicate. Please advise me with this one, if this solution is wrong.