### PR TITLE
Fix for email addresses with accented and non-ASCII characters (IMAP sync)

### DIFF
--- a/src/Oro/Bundle/EmailBundle/Builder/EmailEntityBatchProcessor.php
+++ b/src/Oro/Bundle/EmailBundle/Builder/EmailEntityBatchProcessor.php
@@ -90,7 +90,7 @@ class EmailEntityBatchProcessor implements EmailEntityBatchInterface
      */
     public function addAddress(EmailAddress $obj)
     {
-        $key = strtolower($obj->getEmail());
+        $key = transliterator_transliterate('Any-Latin;Latin-ASCII;Lower;', $obj->getEmail());
         if (isset($this->addresses[$key])) {
             throw new \LogicException(sprintf('The email address "%s" already exists in the batch.', $obj->getEmail()));
         }


### PR DESCRIPTION
Occasionally during IMAP sync the email address is received with foreign non-ASCII characters
which are in PHP treated separately from purely ASCII ones. This later creates SQL Unique violation
as it is flushed into database, where it's treated identically as ASCII characters.

For example:
- émáil@example.com
- email@example.com

is added to addresses under different key during IMAP sync. However during flush to database both
above addresses are treated as 'email@example.com', so it triggers MySQL error with `oro_email_address_uq` constraint.
This converts it to use only ASCII characters for email.