### PR TITLE
Load segment data asynchronously

### DIFF
--- a/src/Oro/Bundle/SegmentBundle/Resources/views/Segment/view.html.twig
+++ b/src/Oro/Bundle/SegmentBundle/Resources/views/Segment/view.html.twig
@@ -54,8 +54,27 @@
             {% set gridParams = gridParams|merge({'display_sql_query': true}) %}
         {% endif %}
         {% set params = params|default({})|merge(gridParams) %}
-        {{ dataGrid.renderGrid(gridName, params, renderParams) }}
-    {% else %}
+        <div id="async-datagrid">
+            {% include "OroUIBundle::view_loading.html.twig" %}
+        </div>
+
+        <script type="text/javascript">
+
+          require(['jquery', 'oroui/js/app/components/component-manager'],
+            function ($, ComponentManager) {
+              var $asyncDatagrid = $('#async-datagrid')
+
+              $.get('{{ path('oro_datagrid_widget', {gridName: gridName} ) }}', {
+                  params: {{ params | json_encode|raw }},
+                  renderParams: {{ renderParams |json_encode |raw }}
+                },
+                function (data) {
+                  $asyncDatagrid.html(data)
+                  var manager = new ComponentManager($asyncDatagrid)
+                  manager.init()
+                })
+            })
+        </script>    {% else %}
         <div class="container-fluid">
             <div class="grid-container">
                 <div class="no-data">

--- a/src/Oro/Bundle/SegmentBundle/Resources/views/Segment/view.html.twig
+++ b/src/Oro/Bundle/SegmentBundle/Resources/views/Segment/view.html.twig
@@ -66,8 +66,7 @@
               blockWidget.render();
             });
         </script>
-
-{% else %}
+    {% else %}
         <div class="container-fluid">
             <div class="grid-container">
                 <div class="no-data">

--- a/src/Oro/Bundle/SegmentBundle/Resources/views/Segment/view.html.twig
+++ b/src/Oro/Bundle/SegmentBundle/Resources/views/Segment/view.html.twig
@@ -54,27 +54,20 @@
             {% set gridParams = gridParams|merge({'display_sql_query': true}) %}
         {% endif %}
         {% set params = params|default({})|merge(gridParams) %}
-        <div id="async-datagrid">
-            {% include "OroUIBundle::view_loading.html.twig" %}
-        </div>
-
+        <div id="segment-datagrid-container"></div>
         <script type="text/javascript">
+          require(['oroui/js/widget-manager', 'oro/block-widget'],
+            function(widgetManager, BlockWidget ) {
+              var blockWidget = new BlockWidget({
+                loadingElement: '#segment-datagrid-container',
+                container: '#segment-datagrid-container',
+                url: '{{  path('oro_datagrid_widget', {gridName: gridName, params: params, renderParams : renderParams} ) }}',
+              });
+              blockWidget.render();
+            });
+        </script>
 
-          require(['jquery', 'oroui/js/app/components/component-manager'],
-            function ($, ComponentManager) {
-              var $asyncDatagrid = $('#async-datagrid')
-
-              $.get('{{ path('oro_datagrid_widget', {gridName: gridName} ) }}', {
-                  params: {{ params | json_encode|raw }},
-                  renderParams: {{ renderParams |json_encode |raw }}
-                },
-                function (data) {
-                  $asyncDatagrid.html(data)
-                  var manager = new ComponentManager($asyncDatagrid)
-                  manager.init()
-                })
-            })
-        </script>    {% else %}
+{% else %}
         <div class="container-fluid">
             <div class="grid-container">
                 <div class="no-data">


### PR DESCRIPTION
Segment QueryFilter can be quite complex and long to execute, this change allow to load the datagrid async, therefore allowing the page to load quickly

Require fix by #961
Related to #925

I am mostly sure that you wont merge this PR as is, but it give you a starting point to fix this issue

