### PR TITLE
Disable the validation of segment filter form

### DIFF
--- a/src/Oro/Bundle/SegmentBundle/Filter/SegmentFilter.php
+++ b/src/Oro/Bundle/SegmentBundle/Filter/SegmentFilter.php
@@ -118,6 +118,7 @@ class SegmentFilter extends EntityFilter
                 [],
                 [
                     'csrf_protection' => false,
+                    'validation_groups' => false,
                     'field_options'   => [
                         'class'         => 'OroSegmentBundle:Segment',
                         'choice_label'  => 'name',


### PR DESCRIPTION
Hi team,
All oro filters (like datetime, string and other) uses symfony forms for transforming filter data from user input input data. All default entity validator will be trigger, if filter form data contains the entity. Oro segments are also was implemented via a filter model. So when we use segments, all validators for segment entity will be trigger again and again.
https://github.com/oroinc/platform/blob/master/src/Oro/Bundle/SegmentBundle/Resources/config/validation.yml#L1-L8
It leads to duplicate sql queries and performance degradation
![Selection_999(604)](https://user-images.githubusercontent.com/21358010/67243839-274eee00-f461-11e9-852c-bdd595f0d0a4.png)


Fixed https://github.com/oroinc/platform/issues/925