### PR TITLE
Fix missing $joinMap in AbstractQueryConverter

### DIFF
--- a/src/Oro/Bundle/QueryDesignerBundle/QueryDesigner/AbstractQueryConverter.php
+++ b/src/Oro/Bundle/QueryDesignerBundle/QueryDesigner/AbstractQueryConverter.php
@@ -1330,7 +1330,11 @@ abstract class AbstractQueryConverter
                     }
                     $joinType     = $mapItem['type'];
                     $join         = $query['join'][$joinType][$mapItem['key']];
-                    $parentJoinId = $this->getParentJoinIdForVirtualColumnJoin($join['join'], $mainEntityJoinId);
+                    $parentJoinId = $this->getParentJoinIdForVirtualColumnJoin(
+                        $join['join'],
+                        $mainEntityJoinId,
+                        $joinMap
+                    );
                     if (null !== $parentJoinId) {
                         $alias    = $join['alias'];
                         $joinId   = $this->buildJoinIdentifier($join, $parentJoinId, $joinType);
@@ -1347,7 +1351,8 @@ abstract class AbstractQueryConverter
                             $join         = $query['join'][$joinType][$mapItem['key']];
                             $parentJoinId = $this->getParentJoinIdForVirtualColumnJoin(
                                 $join['join'],
-                                $mainEntityJoinId
+                                $mainEntityJoinId,
+                                $joinMap
                             );
                             if (null !== $parentJoinId) {
                                 $alias    = $join['alias'];
@@ -1402,10 +1407,11 @@ abstract class AbstractQueryConverter
     /**
      * @param string $joinExpr
      * @param string $mainEntityJoinId
+     * @param array $joinMap
      *
      * @return string|null
      */
-    protected function getParentJoinIdForVirtualColumnJoin($joinExpr, $mainEntityJoinId)
+    protected function getParentJoinIdForVirtualColumnJoin($joinExpr, $mainEntityJoinId, $joinMap)
     {
         $parts = explode('.', $joinExpr, 2);
 


### PR DESCRIPTION
In `AbstractQueryConverter::getParentJoinIdForVirtualColumnJoin` method, `$joinMap` variable is missing.
So we never enter in last elseif `isset($joinMap[$parentAlias]['processed'])`
And when we have 2 joins in a virtual_fields the second join is not added in DQL

Example:
```yaml
# src/Oro/Bundle/AccountBundle/Resources/config/oro/entity.yml
oro_entity:
    virtual_fields:
        Oro\Bundle\AccountBundle\Entity\Account:
            contactInformation:
                query:
                    select:
                        expr:         emails.email
                        return_type:  string
                    join:
                        left:
                            - { join: entity.defaultContact, alias: defaultContact }
                            - { join: defaultContact.emails, alias: emails, conditionType: 'WITH', condition: 'emails.primary = true' }
```

Need for fix this https://github.com/oroinc/crm/pull/346