### PR TITLE
Fix incorrect namespace for UpdateEnumEntityTranslations

### DIFF
--- a/src/Oro/Bundle/EntityExtendBundle/Migrations/Data/ORM/UpdateEnumEntityTranslations.php
+++ b/src/Oro/Bundle/EntityExtendBundle/Migrations/Data/ORM/UpdateEnumEntityTranslations.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Oro\Bundle\EntityExtendBundle\Migrations\Date\ORM;
+namespace Oro\Bundle\EntityExtendBundle\Migrations\Data\ORM;
 
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\Persistence\ObjectManager;


### PR DESCRIPTION
Currently this class cannot be autoloaded, this PR should make that possible again.