### PR TITLE
Use column_name attribute rather than fieldName

### DIFF
--- a/src/Oro/Bundle/EntityExtendBundle/ORM/IndexMetadataBuilder.php
+++ b/src/Oro/Bundle/EntityExtendBundle/ORM/IndexMetadataBuilder.php
@@ -46,13 +46,14 @@ class IndexMetadataBuilder implements MetadataBuilderInterface
         $indices   = $extendConfig->get('index');
         // TODO: need to be changed to fieldName => columnName
         // TODO: should be done in scope https://magecore.atlassian.net/browse/BAP-3940
-        foreach ($indices as $columnName => $indexType) {
-            $fieldConfig = $this->extendConfigProvider->getConfig($className, $columnName);
+        foreach ($indices as $fieldName => $indexType) {
+            $fieldConfig = $this->extendConfigProvider->getConfig($className, $fieldName);
+            $columnName = $fieldConfig->get('column_name', false, $fieldName);
 
             if ($indexType && !$fieldConfig->is('state', ExtendScope::STATE_NEW)) {
                 $indexName = $this->nameGenerator->generateIndexNameForExtendFieldVisibleInGrid(
                     $className,
-                    $columnName
+                    $fieldName
                 );
                 if ((int)$indexType === IndexScope::INDEX_UNIQUE) {
                     $metadataBuilder->addUniqueConstraint([$columnName], $indexName);


### PR DESCRIPTION
In some cases if you try to keep update structure clean and use column_name attribute inside field config doctrine schema update breaks, because this builder tries to build index based on field name rather than column name. This PR fixes this issue.