### PR TITLE
Workflow autostart issues #987

### DIFF
--- a/src/Oro/Bundle/WorkflowBundle/EventListener/WorkflowStartListener.php
+++ b/src/Oro/Bundle/WorkflowBundle/EventListener/WorkflowStartListener.php
@@ -48,7 +48,10 @@ class WorkflowStartListener
         }
 
         foreach ($this->getApplicableWorkflowsForStart($entity) as $activeWorkflow) {
-            if ($activeWorkflow->getStepManager()->hasStartStep()) {
+            if (
+                $activeWorkflow->getStepManager()->hasStartStep()
+                || $activeWorkflow->getTransitionManager()->getStartTransition(null)
+            ) {
                 $this->entitiesScheduledForWorkflowStart[$this->deepLevel][] = new WorkflowStartArguments(
                     $activeWorkflow->getName(),
                     $entity


### PR DESCRIPTION
This change fixes issue where __start__ transition is defined but skipped due to missing start_step.
Also this should add all is_start transitions into consideration, but for now everywhere __start__ is hardcoded and I have no confidence in fixing multiple transitions autostarts.