### PR TITLE
Ensure there are no duplicate layout ids pushed to the array, fixes OSD-4936

### DIFF
--- a/src/Oro/Bundle/UIBundle/Resources/public/js/layout-subtree-manager.js
+++ b/src/Oro/Bundle/UIBundle/Resources/public/js/layout-subtree-manager.js
@@ -34,7 +34,11 @@ define([
                         this.reloadEvents[eventItem] = [];
                         mediator.on(eventItem, this._reloadLayouts.bind(this, eventItem), this);
                     }
-                    this.reloadEvents[eventItem].push(blockId);
+                    
+                    if (!this.reloadEvents[eventItem].includes(blockId))
+                    {
+                        this.reloadEvents[eventItem].push(blockId);
+                    }
                 }).bind(this));
             }
         },


### PR DESCRIPTION
When multiple elements on the page are using layout subtree update block type changing variant leads to the same id pushed to the array mutiple times (reported as OSD-4936 ). This check ensures that each id is added only once.