### PR TITLE
Notification recipients list is not as expected

### DIFF
--- a/src/Oro/Bundle/NotificationBundle/Provider/AdditionalEmailAssociationProvider.php
+++ b/src/Oro/Bundle/NotificationBundle/Provider/AdditionalEmailAssociationProvider.php
@@ -70,8 +70,11 @@ class AdditionalEmailAssociationProvider implements AdditionalEmailAssociationPr
      */
     public function getAssociationValue($entity, string $associationName)
     {
-        return $this->getEntityMetadata(ClassUtils::getClass($entity))
-            ->getFieldValue($entity, $associationName);
+        $propertyAccessor = new PropertyAccessor();
+
+        return $propertyAccessor->isReadable($entity, $associationName)
+            ? $propertyAccessor->getValue($entity, $associationName)
+            : null;
     }
 
     /**


### PR DESCRIPTION
We have encountered a bug, where doctrine metadata wont lazy load relations and in that case our notification recipients list is not as expected. Lots of users have not received their email because of this bug, it is maybe a Doctrine issue, but im adding PR just in case for someone with same bug.

When we use property accessor then we basically use getters and all the relations will be lazy loaded.