### PR TITLE
ArraySorterExtension DateTime support

### DIFF
--- a/src/Oro/Bundle/DataGridBundle/Extension/Sorter/ArraySorterExtension.php
+++ b/src/Oro/Bundle/DataGridBundle/Extension/Sorter/ArraySorterExtension.php
@@ -73,6 +73,10 @@ class ArraySorterExtension extends AbstractSorterExtension
      */
     protected function safeStringConvert($value)
     {
+        if ($value instanceof \DateTime) {
+            $value = $value->getTimestamp();
+        }
+
         return iconv('utf-8', 'ascii//TRANSLIT', strtolower((string)$value));
     }
 }


### PR DESCRIPTION
We have array of objects, objects implements ArrayAccess, everything works fine except sorting by DateTime does not work. I dunno if this is the right solution, but if someone has this issue, you can extend this extension and add this. Ofc by oro logic, array should be array, but in our project we use models in some places and we need datagrid for that.