### PR TITLE
feat: change utf8 to utf8mb4 encoding and utf8_bin collation to utf8mb4_bin for TranslationBundle

### DIFF
--- a/src/Oro/Bundle/TranslationBundle/Entity/TranslationKey.php
+++ b/src/Oro/Bundle/TranslationBundle/Entity/TranslationKey.php
@@ -5,10 +5,10 @@ namespace Oro\Bundle\TranslationBundle\Entity;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
- * "utf8_bin" required for mysql to support case-sensitive values for "key" column
+ * "utf8mb4_bin" required for mysql to support case-sensitive values for "key" column
  *
  * @ORM\Entity(repositoryClass="Oro\Bundle\TranslationBundle\Entity\Repository\TranslationKeyRepository")
- * @ORM\Table(name="oro_translation_key", options={"collate"="utf8_bin", "charset"="utf8"}, uniqueConstraints={
+ * @ORM\Table(name="oro_translation_key", options={"collate"="utf8mb4_bin", "charset"="utf8mb4"}, uniqueConstraints={
  *      @ORM\UniqueConstraint(name="key_domain_uniq", columns={"key", "domain"})
  * })
  */

--- a/src/Oro/Bundle/TranslationBundle/Migrations/Schema/OroTranslationBundleInstaller.php
+++ b/src/Oro/Bundle/TranslationBundle/Migrations/Schema/OroTranslationBundleInstaller.php
@@ -84,8 +84,8 @@ class OroTranslationBundleInstaller implements Installation
         /**
          * Required to support Case Sensitive keys in MySQL
          */
-        $table->addOption('charset', 'utf8');
-        $table->addOption('collate', 'utf8_bin');
+        $table->addOption('charset', 'utf8mb4');
+        $table->addOption('collate', 'utf8mb4_bin');
     }
 
     /**

--- a/src/Oro/Bundle/TranslationBundle/Migrations/Schema/v1_3/MigrateTranslationDataQuery.php
+++ b/src/Oro/Bundle/TranslationBundle/Migrations/Schema/v1_3/MigrateTranslationDataQuery.php
@@ -54,7 +54,7 @@ class MigrateTranslationDataQuery extends ParametrizedMigrationQuery
             //In cases when we have Case Insensitive characterset for `key` column
             $queries[] = [
                 'ALTER TABLE `oro_translation` MODIFY COLUMN `key`  varchar(255) ' .
-                    'CHARACTER SET utf8 COLLATE utf8_bin NOT NULL AFTER `id`;',
+                    'CHARACTER SET utf8mb4 COLLATE utf8mb4_bin NOT NULL AFTER `id`;',
                 [],
                 [],
             ];

--- a/src/Oro/Bundle/TranslationBundle/Migrations/Schema/v1_3/OroTranslationBundle.php
+++ b/src/Oro/Bundle/TranslationBundle/Migrations/Schema/v1_3/OroTranslationBundle.php
@@ -44,8 +44,8 @@ class OroTranslationBundle implements Migration, OrderedMigrationInterface
         /**
          * Required to support Case Sensitive keys in MySQL
          */
-        $table->addOption('charset', 'utf8');
-        $table->addOption('collate', 'utf8_bin');
+        $table->addOption('charset', 'utf8mb4');
+        $table->addOption('collate', 'utf8mb4_bin');
     }
 
     /**


### PR DESCRIPTION
I used to have a crm-application setup with utf8 encoding and utf8_unicode_ci collation, so I recently migrate all the tables and database to utf8mb4 encoding and utf8mb4 collation, but I noticed that was an special case with `oro_translation_key` table that needed and special collation to be able be case sensitive, so I checked in the migration that install that table and notice that special collation using "utf8_bin", but since the rest of the tables uses utf8mb4 I'm updating the encoding and collation, keeping the special case scenario, but with utf8mb4 instead of the old utf8.

Let me know if that's okey, I tested with that collation and encoding in my own Database and seems to be working fine. 