### PR TITLE
Reduce logging level from 'notice' to 'info'

### DIFF
--- a/src/Oro/Component/MessageQueue/Consumption/QueueConsumer.php
+++ b/src/Oro/Component/MessageQueue/Consumption/QueueConsumer.php
@@ -215,7 +215,7 @@ class QueueConsumer
                 'time_taken' => $executionTime
             ];
             $this->addMemoryUsageInfo($loggerContext);
-            $logger->notice('Message processed: {status}. Execution time: {time_taken} ms', $loggerContext);
+            $logger->info('Message processed: {status}. Execution time: {time_taken} ms', $loggerContext);
 
             $extension->onPostReceived($context);
         } else {


### PR DESCRIPTION
Reducing the log level from `notice` to `info` to be the same as `'Message received'` message and other informational messages produce by the Queue