### PR TITLE
fix: change executeQuery method to executeUpdate for writing operations

### DIFF
--- a/src/Oro/Bundle/SecurityBundle/Acl/Dbal/MutableAclProvider.php
+++ b/src/Oro/Bundle/SecurityBundle/Acl/Dbal/MutableAclProvider.php
@@ -121,7 +121,7 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
     public function updateSecurityIdentity(SecurityIdentityInterface $sid, $oldName)
     {
         [$sql, $params, $types] = $this->getUpdateSecurityIdentitySql($sid, $oldName);
-        $this->connection->executeQuery($sql, $params, $types);
+        $this->connection->executeUpdate($sql, $params, $types);
     }
 
     /**
@@ -136,7 +136,7 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
         try {
             $this->deleteAcl($oid);
             [$sql, $params, $types] = $this->getDeleteClassIdSql($oid->getType());
-            $this->connection->executeQuery($sql, $params, $types);
+            $this->connection->executeUpdate($sql, $params, $types);
 
             $this->connection->commit();
         } catch (\Exception $failed) {
@@ -212,7 +212,7 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
 
             $pk = $this->retrieveObjectIdentityPrimaryKey($oid);
             [$sql, $params, $types] = $this->getInsertObjectIdentityRelationSql($pk, $pk);
-            $this->connection->executeQuery($sql, $params, $types);
+            $this->connection->executeUpdate($sql, $params, $types);
 
             $this->connection->commit();
         } catch (\Exception $e) {
@@ -280,7 +280,7 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
     public function deleteSecurityIdentity(SecurityIdentityInterface $sid)
     {
         [$sql, $params, $types] = $this->getDeleteSecurityIdentityIdSql($sid);
-        $this->connection->executeQuery($sql, $params, $types);
+        $this->connection->executeUpdate($sql, $params, $types);
     }
 
     /**
@@ -533,7 +533,7 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
             // persist any changes to the acl_object_identities table
             if (count($sets) > 0) {
                 [$sql, $params, $types] = $this->getUpdateObjectIdentitySql($acl->getId(), $sets);
-                $this->connection->executeQuery($sql, $params, $types);
+                $this->connection->executeUpdate($sql, $params, $types);
             }
 
             $this->connection->commit();
@@ -573,7 +573,7 @@ class MutableAclProvider extends AclProvider implements MutableAclProviderInterf
     public function updateUserSecurityIdentity(UserSecurityIdentity $usid, $oldUsername)
     {
         [$sql, $params, $types] = $this->getUpdateUserSecurityIdentitySql($usid, $oldUsername);
-        $this->connection->executeQuery($sql, $params, $types);
+        $this->connection->executeUpdate($sql, $params, $types);
     }
 
     /**
@@ -998,7 +998,7 @@ QUERY;
         $classId = $this->createOrRetrieveClassId($oid->getType());
 
         [$sql, $params, $types] = $this->getInsertObjectIdentitySql($oid->getIdentifier(), $classId, true);
-        $this->connection->executeQuery($sql, $params, $types);
+        $this->connection->executeUpdate($sql, $params, $types);
     }
 
     /**
@@ -1018,7 +1018,7 @@ QUERY;
         }
 
         [$insertSql, $insertParams, $insertTypes] = $this->getInsertClassSql($classType);
-        $this->connection->executeQuery($insertSql, $insertParams, $insertTypes);
+        $this->connection->executeUpdate($insertSql, $insertParams, $insertTypes);
 
         return $this->connection->executeQuery($sql, $params, $types)->fetchColumn();
     }
@@ -1042,7 +1042,7 @@ QUERY;
         }
 
         [$insertSql, $insertParams, $insertTypes] = $this->getInsertSecurityIdentitySql($sid);
-        $this->connection->executeQuery($insertSql, $insertParams, $insertTypes);
+        $this->connection->executeUpdate($insertSql, $insertParams, $insertTypes);
 
         return $this->connection->executeQuery($sql, $params, $types)->fetchColumn();
     }
@@ -1055,7 +1055,7 @@ QUERY;
     private function deleteAccessControlEntries($oidPK)
     {
         [$sql, $params, $types] = $this->getDeleteAccessControlEntriesSql($oidPK);
-        $this->connection->executeQuery($sql, $params, $types);
+        $this->connection->executeUpdate($sql, $params, $types);
     }
 
     /**
@@ -1066,7 +1066,7 @@ QUERY;
     private function deleteObjectIdentity($pk)
     {
         [$sql, $params, $types] = $this->getDeleteObjectIdentitySql($pk);
-        $this->connection->executeQuery($sql, $params, $types);
+        $this->connection->executeUpdate($sql, $params, $types);
     }
 
     /**
@@ -1077,7 +1077,7 @@ QUERY;
     private function deleteObjectIdentityRelations($pk)
     {
         [$sql, $params, $types] = $this->getDeleteObjectIdentityRelationsSql($pk);
-        $this->connection->executeQuery($sql, $params, $types);
+        $this->connection->executeUpdate($sql, $params, $types);
     }
 
     /**
@@ -1089,14 +1089,14 @@ QUERY;
     {
         $pk = $acl->getId();
         [$sql, $params, $types] = $this->getDeleteObjectIdentityRelationsSql($pk);
-        $this->connection->executeQuery($sql, $params, $types);
+        $this->connection->executeUpdate($sql, $params, $types);
         [$sql, $params, $types] = $this->getInsertObjectIdentityRelationSql($pk, $pk);
-        $this->connection->executeQuery($sql, $params, $types);
+        $this->connection->executeUpdate($sql, $params, $types);
 
         $parentAcl = $acl->getParentAcl();
         while (null !== $parentAcl) {
             [$sql, $params, $types] = $this->getInsertObjectIdentityRelationSql($pk, $parentAcl->getId());
-            $this->connection->executeQuery($sql, $params, $types);
+            $this->connection->executeUpdate($sql, $params, $types);
 
             $parentAcl = $parentAcl->getParentAcl();
         }
@@ -1144,7 +1144,7 @@ QUERY;
                         $ace->isAuditSuccess(),
                         $ace->isAuditFailure()
                     );
-                    $this->connection->executeQuery($sql, $params, $types);
+                    $this->connection->executeUpdate($sql, $params, $types);
 
                     [$sql, $params, $types] = $this->getSelectAccessControlEntryIdSql(
                         $classId,
@@ -1185,7 +1185,7 @@ QUERY;
             foreach ($old as $ace) {
                 if (!isset($currentIds[$ace->getId()])) {
                     [$sql, $params, $types] = $this->getDeleteAccessControlEntrySql($ace->getId());
-                    $this->connection->executeQuery($sql, $params, $types);
+                    $this->connection->executeUpdate($sql, $params, $types);
                     unset($this->loadedAces[$ace->getId()]);
                 }
             }
@@ -1235,7 +1235,7 @@ QUERY;
                     $ace->isAuditSuccess(),
                     $ace->isAuditFailure()
                 );
-                $this->connection->executeQuery($sql, $params, $types);
+                $this->connection->executeUpdate($sql, $params, $types);
 
                 [$sql, $params, $types] = $this->getSelectAccessControlEntryIdSql(
                     $classId,
@@ -1274,7 +1274,7 @@ QUERY;
         foreach ($old as $ace) {
             if (!isset($currentIds[$ace->getId()])) {
                 [$sql, $params, $types] = $this->getDeleteAccessControlEntrySql($ace->getId());
-                $this->connection->executeQuery($sql, $params, $types);
+                $this->connection->executeUpdate($sql, $params, $types);
                 unset($this->loadedAces[$ace->getId()]);
             }
         }
@@ -1332,6 +1332,6 @@ QUERY;
             );
         }
 
-        $this->connection->executeQuery($this->getUpdateAccessControlEntrySql($ace->getId(), $sets));
+        $this->connection->executeUpdate($this->getUpdateAccessControlEntrySql($ace->getId(), $sets));
     }
 }

--- a/src/Oro/Bundle/SecurityBundle/Tests/Unit/Acl/Dbal/MutableAclProviderTest.php
+++ b/src/Oro/Bundle/SecurityBundle/Tests/Unit/Acl/Dbal/MutableAclProviderTest.php
@@ -87,7 +87,7 @@ class MutableAclProviderTest extends \PHPUnit\Framework\TestCase
     public function testDeleteSecurityIdentity(SecurityIdentityInterface $sid, $parameters)
     {
         $this->connection->expects($this->once())
-            ->method('executeQuery')
+            ->method('executeUpdate')
             ->with(
                 'DELETE FROM acl_security_identities WHERE identifier = ? AND username = ?',
                 $parameters,
@@ -102,7 +102,7 @@ class MutableAclProviderTest extends \PHPUnit\Framework\TestCase
     public function testUpdateSecurityIdentity(SecurityIdentityInterface $sid, $oldName, $parameters)
     {
         $this->connection->expects($this->once())
-            ->method('executeQuery')
+            ->method('executeUpdate')
             ->with(
                 'UPDATE acl_security_identities SET identifier = ? WHERE identifier = ? AND username = ?',
                 $parameters,
@@ -180,7 +180,7 @@ class MutableAclProviderTest extends \PHPUnit\Framework\TestCase
             ->method('deleteAcl')
             ->with($this->identicalTo($oid));
         $this->connection->expects($this->once())
-            ->method('executeQuery')
+            ->method('executeUpdate')
             ->with(
                 'DELETE FROM acl_classes WHERE class_type = ?',
                 ['Test\Class'],
@@ -216,7 +216,7 @@ class MutableAclProviderTest extends \PHPUnit\Framework\TestCase
             ->method('deleteAcl')
             ->with($this->identicalTo($oid));
         $this->connection->expects($this->once())
-            ->method('executeQuery')
+            ->method('executeUpdate')
             ->willThrowException(new \Exception('some exception'));
         $this->connection->expects($this->once())
             ->method('rollBack');


### PR DESCRIPTION
I noticed in a crm-application project that you are using `executeQuery` doctrine method for writing operations, for most systems it doesn't matter and probably they are not gonna have any errors, but for systems that have a `master` and `slave` databases configured in doctrine it results in errors since the slave normally is configured to be read-only and using  `executeQuery` leads to Doctrine trying to use the slave read-only instance to insert, delete or update data, causing errors like the following in Mysql when for example you try to delete a Role: 

```
Error Code: 1290. The MySQL server is running with the –read-only option so it cannot execute this statement
```

This PR changes the `executeQuery` for `executeUpdate` for the writing cases. 

I noticed too that you have that because in the symfony-acl original package is the same error, so
I also did the same PR for the symfony/security-acl package, but it seems that the package is not supported actively anymore, so it will be probably be ignored:

https://github.com/symfony/security-acl/pull/56

I hope it helps. 