### PR TITLE
Point configuration provider to /Resources/config/oro

### DIFF
--- a/src/Oro/Bundle/WorkflowBundle/Configuration/AbstractConfigurationProvider.php
+++ b/src/Oro/Bundle/WorkflowBundle/Configuration/AbstractConfigurationProvider.php
@@ -11,7 +11,7 @@ abstract class AbstractConfigurationProvider
     /**
      * @var string
      */
-    protected $configDirectory = '/Resources/config/';
+    protected $configDirectory = '/Resources/config/oro';
 
     /**
      * @var array


### PR DESCRIPTION
Fix location directory for `processes.yml` config files loaded in the Workflow bundle.
All `/Resources/config/*/processes.yml` are located in `/Resources/config/oro/`
Please see `find . -name processes.yml`.

This patch prevents `oro:process:configuration:load` command from failing with system error "Too many files open" due to heavy recursive directory scan.