### PR TITLE
Allow to generate the password instead of providing it in plain text

### DIFF
--- a/src/Oro/Bundle/UserBundle/Command/CreateUserCommand.php
+++ b/src/Oro/Bundle/UserBundle/Command/CreateUserCommand.php
@@ -58,7 +58,7 @@ class CreateUserCommand extends Command
             ->addOption('user-email', null, InputOption::VALUE_REQUIRED, 'User email (required)')
             ->addOption('user-firstname', null, InputOption::VALUE_REQUIRED, 'User first name')
             ->addOption('user-lastname', null, InputOption::VALUE_REQUIRED, 'User last name')
-            ->addOption('user-password', null, InputOption::VALUE_REQUIRED, 'User password (required)')
+            ->addOption('user-password', null, InputOption::VALUE_OPTIONAL, 'User password (password will be generated if ommited)')
             ->addOption(
                 'user-organizations',
                 null,
@@ -100,8 +100,7 @@ class CreateUserCommand extends Command
         $requiredOptions = [
             'user-business-unit',
             'user-name',
-            'user-email',
-            'user-password'
+            'user-email'
         ];
 
         foreach ($requiredOptions as $requiredOption) {
@@ -126,6 +125,8 @@ class CreateUserCommand extends Command
 
         if (!empty($options['user-password'])) {
             $user->setPlainPassword($options['user-password']);
+        } else {
+            $user->setPlainPassword($this->userManager->generatePassword());
         }
 
         $this


### PR DESCRIPTION
Hello Oro !!!

Small quality of life patch that allow to create users and generating a random password.

Avoiding having to provide password in plain text through command line is a security improvement, since there is no option currently to "Force user to change password on next login"

Have a good day,
Samuel