### PR TITLE
Fixing error with non existent class

### DIFF
--- a/src/Oro/Bundle/AttachmentBundle/Controller/AttachmentController.php
+++ b/src/Oro/Bundle/AttachmentBundle/Controller/AttachmentController.php
@@ -59,7 +59,7 @@ class AttachmentController extends AbstractController
         $entityRoutingHelper = $this->getEntityRoutingHelper();
 
         $entity      = $entityRoutingHelper->getEntity($entityClass, $entityId);
-        $entityClass = get_class($entity);
+        $parentEntityClass = get_class($entity);
 
         $attachmentEntity = new Attachment();
         $attachmentEntity->setTarget($entity);
@@ -67,7 +67,7 @@ class AttachmentController extends AbstractController
         $form       = $this->createForm(
             AttachmentType::class,
             $attachmentEntity,
-            ['parentEntityClass' => $entityClass, 'checkEmptyFile' => true]
+            ['parentEntityClass' => $parentEntityClass, 'checkEmptyFile' => true]
         );
 
         $formAction = $entityRoutingHelper->generateUrlByRequest(


### PR DESCRIPTION
$entityClass was updating from:

"Oro_Bundle_OrganizationBundle_Entity_BusinessUnit"

to:

"Proxies/___CG___/Oro_Bundle_OrganizationBundle_Entity_BusinessUnit"

Which causes

Fatal error:  require(): Failed opening required '/var/www/html/demo/var/cache/prod/doctrine/orm/Proxies/___CG___Oro_Bundle_OrganizationBundle_Entity_BusinessUnit.php'

When attempting to add an attachment on a Business Unit, reproduced here:
First add attachments to business units in the entity configuration:
https://demo.orocrm.com/index.php/organization/business_unit/view/1

Once an attachment has been added to the Business Unit, this incorrect URL is generated:
https://demo.orocrm.com/index.php/attachment/create/Proxies___CG___Oro_Bundle_OrganizationBundle_Entity_BusinessUnit/1?_widgetContainer=dialog&_wid=ee7ba2d3-5903-4207-a15a-3bebce87ff1f&_widgetInit=1