### PR TITLE
fix: check image processor installation status

### DIFF
--- a/src/Oro/Bundle/InstallerBundle/Provider/PlatformRequirementsProvider.php
+++ b/src/Oro/Bundle/InstallerBundle/Provider/PlatformRequirementsProvider.php
@@ -788,7 +788,7 @@ class PlatformRequirementsProvider extends AbstractRequirementsProvider
     {
         $library = null;
         try {
-            [$library, ] = $this->getImageProcessorLibrary($libraryName, $this->imageProcessorConfig);
+            $library = $this->getImageProcessorLibrary($libraryName, $this->imageProcessorConfig);
         } catch (ProcessorsException $exception) {
             return;
         } catch (ProcessorsVersionException $exception) {


### PR DESCRIPTION
Calling `getImageProcessorLibrary` actually returns a String, not an Array. 

Interestingly, this is correctly implemented in another method in the same class:

https://github.com/oroinc/platform/blob/df0bfdccd8cd5b5af52639ae5999b3955caaeb81/src/Oro/Bundle/InstallerBundle/Provider/PlatformRequirementsProvider.php#L525-L531

fixes #1068