### PR TITLE
AclHelper: ensure $owners can be json_serialized to an array

### DIFF
--- a/src/Oro/Bundle/SecurityBundle/Search/AclHelper.php
+++ b/src/Oro/Bundle/SecurityBundle/Search/AclHelper.php
@@ -164,7 +164,7 @@ class AclHelper
         if (\is_array($owners)) {
             return \count($owners) === 1
                 ? $expressionBuilder->eq('integer.' . $filterField, reset($owners))
-                : $expressionBuilder->in('integer.' . $filterField, $owners);
+                : $expressionBuilder->in('integer.' . $filterField, array_values($owners));
         }
 
         return $expressionBuilder->eq('integer.' . $filterField, $owners);


### PR DESCRIPTION
Tested on OroCRM 4.2 and PHP 8.
Currently, when using ElasticSearch as a search engine, queries that contain an ACL ownership condition are generated incorrectly.
E.g.: this fragment:
`... {"terms":{"oro_email_campaign_owner":{"0":76,"1":1,"2":2,"3":3 ...`
Should instead be serialized as:
`... {"terms":{"oro_email_campaign_owner":[76, 1, 2, 3 ....`
This leads to ES rejecting the query because of a syntax error.

This PR ensures that the owner array is not keyed with strings, thus being wrongly json_serialized while producing an ES query.