### PR TITLE
dynamically Import widget manager

### DIFF
--- a/src/Oro/Bundle/UIBundle/Resources/config/oro/jsmodules.yml
+++ b/src/Oro/Bundle/UIBundle/Resources/config/oro/jsmodules.yml
@@ -146,6 +146,7 @@ dynamic-imports:
         - oroui/js/standart-confirmation
         - oroui/js/tools/api-accessor
         - oroui/js/tools/search-api-accessor
+        - oroui/js/widget-manager
         - underscore
     jstree:
         - oroui/js/app/views/jstree/base-tree-view


### PR DESCRIPTION
To use widget manager inside twig templates with `loadModules` its necessary to dynamically import it.

Example:
```twig
    <script type="text/javascript">
        loadModules(['oroui/js/widget-manager'],
            function(widgetManager) {
                widgetManager.getWidgetInstance({{ app.request.get('_wid')|json_encode|raw }}, function(widget) {
                    ...
                });
            });
    </script>
```

I can do it also by my own, but ATM there are so many `dynamic-imports` and I'm not quite sure why the widget manager is missing.

Thx.
