### PR TITLE
Add a missing space for phpdoc in AttributeManager

### DIFF
--- a/src/Oro/Bundle/EntityConfigBundle/Manager/AttributeManager.php
+++ b/src/Oro/Bundle/EntityConfigBundle/Manager/AttributeManager.php
@@ -280,7 +280,7 @@ class AttributeManager
         /** @var AttributeGroup $group */
         foreach ($groups as $group) {
             $item = ['group' => $group, 'attributes' => []];
-            /** @var AttributeGroupRelation$attributeRelation */
+            /** @var AttributeGroupRelation $attributeRelation */
             foreach ($group->getAttributeRelations() as $attributeRelation) {
                 $item['attributes'][] = $attributes[$attributeRelation->getEntityConfigFieldId()];
             }


### PR DESCRIPTION
Hi,

There was a missing space for a phpdoc line, so IDE couldn't understand what was $attributeRelation.