### PR TITLE
Fix SegmentBundle migration to support MySQL platform as well as PgSQL

### DIFF
--- a/src/Oro/Bundle/SegmentBundle/Migrations/Schema/v1_11/RemoveDuplicateSnapshots.php
+++ b/src/Oro/Bundle/SegmentBundle/Migrations/Schema/v1_11/RemoveDuplicateSnapshots.php
@@ -2,15 +2,31 @@
 
 namespace Oro\Bundle\SegmentBundle\Migrations\Schema\v1_11;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQL94Platform;
 use Doctrine\DBAL\Schema\Schema;
+use Oro\Bundle\MigrationBundle\Migration\ConnectionAwareInterface;
 use Oro\Bundle\MigrationBundle\Migration\Migration;
 use Oro\Bundle\MigrationBundle\Migration\QueryBag;
 
-class RemoveDuplicateSnapshots implements Migration
+class RemoveDuplicateSnapshots implements Migration, ConnectionAwareInterface
 {
+    /** @var Connection */
+    private $connection;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setConnection(Connection $connection)
+    {
+        $this->connection = $connection;
+    }
+
     public function up(Schema $schema, QueryBag $queries)
     {
-        $this->removeDuplicateSnapshots($queries);
+        $platform = $this->connection->getDatabasePlatform();
+        $this->removeDuplicateSnapshots($platform, $queries);
         $this->addUniqueKey($schema);
     }
 
@@ -23,9 +39,13 @@ class RemoveDuplicateSnapshots implements Migration
         );
     }
 
-    private function removeDuplicateSnapshots(QueryBag $queries): void
+    private function removeDuplicateSnapshots(
+        AbstractPlatform $platform,
+        QueryBag $queries
+    ): void
     {
-        $sql = <<<SQL
+        if ($platform instanceof PostgreSQL94Platform) {
+            $sql = <<<SQL
             DELETE FROM oro_segment_snapshot oro_segment_snapshot_1
             USING oro_segment_snapshot oro_segment_snapshot_2
             WHERE
@@ -33,7 +53,16 @@ class RemoveDuplicateSnapshots implements Migration
                 AND oro_segment_snapshot_1.segment_id = oro_segment_snapshot_2.segment_id
                 AND oro_segment_snapshot_1.integer_entity_id = oro_segment_snapshot_2.integer_entity_id
         SQL;
-
+        } else {
+            $sql = <<<SQL
+            DELETE FROM oro_segment_snapshot_1
+                USING oro_segment_snapshot oro_segment_snapshot_2 JOIN oro_segment_snapshot oro_segment_snapshot_1
+                WHERE
+                    oro_segment_snapshot_1.id < oro_segment_snapshot_2.id
+                    AND oro_segment_snapshot_1.segment_id = oro_segment_snapshot_2.segment_id
+                    AND oro_segment_snapshot_1.integer_entity_id = oro_segment_snapshot_2.integer_entity_id
+        SQL;
+        }
         $queries->addPreQuery($sql);
     }
 }


### PR DESCRIPTION
Fix migration v1.11 in SegmentBundle to support MySQL platform as well as the current PgSQL with its plain query execution.

* Make the migration connection aware
* Tested so that migrating from 4.2 on MySQL to 5.1 (on MySQL as well) will not failed due to this migration plain query, this fix will allow the execution of queries against the current MySQL before any planned PgSQL platform change on running systems.