### PR TITLE
Fix: exception thrown when serialize called on ConfigObject

### DIFF
--- a/src/Oro/Component/Config/Common/ConfigObject.php
+++ b/src/Oro/Component/Config/Common/ConfigObject.php
@@ -326,4 +326,12 @@ class ConfigObject implements \ArrayAccess, \IteratorAggregate
 
         return $this;
     }
+
+    /**
+     * @return array<int, string>
+     */
+    public function __sleep(): array
+    {
+        return ['params'];
+    }
 }


### PR DESCRIPTION
Specifically when `\Oro\Bundle\EntityBundle\DataCollector\Analyzer\DuplicateQueryAnalyzer::getIdenticalQueries` generates a query key for a query which has a param which is an `\Oro\Component\Config\Common\ConfigObject`