### PR TITLE
Change visibility to "protected" on LoadLocalizationDemoData::$localizations

### DIFF
--- a/src/Oro/Bundle/LocaleBundle/Migrations/Data/Demo/ORM/LoadLocalizationDemoData.php
+++ b/src/Oro/Bundle/LocaleBundle/Migrations/Data/Demo/ORM/LoadLocalizationDemoData.php
@@ -17,7 +17,7 @@ use Symfony\Component\Intl\Locales;
  */
 class LoadLocalizationDemoData extends AbstractFixture implements ContainerAwareInterface, DependentFixtureInterface
 {
-    private array $localizations = [
+    protected array $localizations = [
         ['language' => LoadLanguageDemoData::LANG_EN_US, 'formatting' => 'en_US', 'parent' => null],
         ['language' => LoadLanguageDemoData::LANG_EN_CA, 'formatting' => 'en_CA', 'parent' => 'en_US'],
         ['language' => LoadLanguageDemoData::LANG_EN_GB, 'formatting' => 'en_GB', 'parent' => 'en_US'],


### PR DESCRIPTION
The goal is be able to add locales just by extending this class and overwrite the `$localizations` property just like the [LoadLanguageDemoData migration](https://github.com/oroinc/platform/blob/master/src/Oro/Bundle/TranslationBundle/Migrations/Data/Demo/ORM/LoadLanguageDemoData.php#L28) in order to add languages.