### PR TITLE
Support lazy command definition in CronDefinitionsLoadCommand

### DIFF
--- a/src/Oro/Bundle/CronBundle/Command/CronDefinitionsLoadCommand.php
+++ b/src/Oro/Bundle/CronBundle/Command/CronDefinitionsLoadCommand.php
@@ -7,6 +7,7 @@ namespace Oro\Bundle\CronBundle\Command;
 use Doctrine\Persistence\ManagerRegistry;
 use Oro\Bundle\CronBundle\Entity\Schedule;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\LazyCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -65,6 +66,9 @@ HELP
         foreach ($applicationCommands as $name => $command) {
             if ($this === $command) {
                 continue;
+            }
+            if ($command instanceof LazyCommand) {
+                $command = $command->getCommand();
             }
             $output->write(sprintf('Processing command "<info>%s</info>": ', $name));
             if ($this->checkCommand($output, $command)) {


### PR DESCRIPTION
When defining cron commands to be [lazy](https://symfony.com/doc/5.4/console/commands_as_services.html#console-command-service-lazy-loading), they will be loaded as instances of [LazyCommand](https://github.com/symfony/console/blob/v5.4.28/Command/LazyCommand.php) and thus fail the `$command instanceof CronCommandScheduleDefinitionInterface` check.

Compare SymfonyConsole [Application::doRun](https://github.com/symfony/console/blob/6.3/Application.php#L315-L317).

This already affects the [RemoveOrphanedMaterializedViewsCronCommand](https://github.com/oroinc/platform/blob/master/src/Oro/Bundle/PlatformBundle/Command/Cron/RemoveOrphanedMaterializedViewsCronCommand.php) definition **not** being loaded