### PR TITLE
Type incompatibility fixed

### DIFF
--- a/src/Oro/Bundle/CurrencyBundle/Entity/Price.php
+++ b/src/Oro/Bundle/CurrencyBundle/Entity/Price.php
@@ -49,7 +49,7 @@ class Price implements CurrencyAwareInterface, \JsonSerializable
      */
     public function setValue($value)
     {
-        $this->value = $value;
+        $this->value = (float) $value;
 
         return $this;
     }


### PR DESCRIPTION
The $value property is declared as float.
by PHPDoc getValue returns float, but setValue accepts string, so it is necessary to cast value to be consistent with the declared type.