### PR TITLE
fixes oroinc/platform#1110 allow to install more recent packages for PHPCS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "ext-xml": "*",
         "ext-zip": "*",
         "composer-plugin-api": "^2.1",
-        "composer/semver": "~3.3.2",
+        "composer/semver": "^3.3.2",
         "psr/container": "^1.0",
         "psr/simple-cache": "3.0.*",
         "symfony/asset": "~6.4.0",
@@ -153,7 +153,7 @@
         "symfony/var-dumper": "~6.4.0",
         "symfony/var-exporter": "~6.4.0",
         "symfony/web-profiler-bundle": "~6.4.0",
-        "friendsofphp/php-cs-fixer": "~3.13.1",
+        "friendsofphp/php-cs-fixer": "^3.13.1",
         "oro/twig-inspector": "1.1.*"
     },
     "provide": {

--- a/dev.json
+++ b/dev.json
@@ -26,7 +26,7 @@
         "ext-xml": "*",
         "ext-zip": "*",
         "composer-plugin-api": "^2.1",
-        "composer/semver": "~3.3.2",
+        "composer/semver": "^3.3.2",
         "psr/container": "^1.0",
         "psr/simple-cache": "3.0.*",
         "symfony/asset": "~6.4.0",
@@ -80,6 +80,7 @@
         "symfony/polyfill-ctype": "1.24.0",
         "symfony/security-acl": "~3.3.2",
         "symfony/acl-bundle": "~2.3.0",
+        "symfony/flex": "2.4.*",
         "twig/twig": "~3.5.0",
         "doctrine/orm": "~2.15.0",
         "doctrine/doctrine-bundle": "~2.7.2",
@@ -100,7 +101,7 @@
         "ass/xmlsecurity": "1.1.1",
         "stof/doctrine-extensions-bundle": "~1.7.0",
         "liip/imagine-bundle": "~2.10.0",
-        "laminas/laminas-mail": "^2.25.0",
+        "laminas/laminas-mail": "~2.25.0",
         "dragonmantank/cron-expression": "~3.3.2",
         "gos/web-socket-bundle": "~3.15.0",
         "guzzlehttp/guzzle": "~7.5.0",
@@ -152,7 +153,7 @@
         "symfony/var-dumper": "~6.4.0",
         "symfony/var-exporter": "~6.4.0",
         "symfony/web-profiler-bundle": "~6.4.0",
-        "friendsofphp/php-cs-fixer": "~3.13.1",
+        "friendsofphp/php-cs-fixer": "^3.13.1",
         "oro/twig-inspector": "1.1.*"
     },
     "provide": {
@@ -164,10 +165,6 @@
         "ext-tidy": "To improve parsing of email content."
     },
     "repositories": {
-        "monorepo": {
-            "type": "path",
-            "url": "../*"
-        },
         "oro": {
             "type": "composer",
             "url": "https://packagist.orocrm.com"
@@ -325,14 +322,12 @@
             "Oro\\Component\\Testing\\": "src/Oro/Component/Testing",
             "Oro\\Component\\TestUtils\\": "src/Oro/Component/TestUtils"
         },
-        "exclude-from-classmap": [
-            "/Tests/"
-        ]
+        "exclude-from-classmap": ["/Tests/"]
     },
     "config": {
         "allow-plugins": {
-            "symfony/runtime": false,
             "php-http/discovery": false,
+            "symfony/runtime": false,
             "symfony/flex": false
         }
     }

--- a/dev.lock
+++ b/dev.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1850152db2e48ca34006f12ec0cdf27f",
+    "content-hash": "20da88a0e9a22d81ff8f147e2f957fe9",
     "packages": [
         {
             "name": "ass/xmlsecurity",
@@ -456,16 +456,16 @@
         },
         {
             "name": "composer/semver",
-            "version": "3.3.2",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/semver.git",
-                "reference": "3953f23262f2bff1919fc82183ad9acb13ff62c9"
+                "reference": "35e8d0af4486141bc745f23a29cc2091eb624a32"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/3953f23262f2bff1919fc82183ad9acb13ff62c9",
-                "reference": "3953f23262f2bff1919fc82183ad9acb13ff62c9",
+                "url": "https://api.github.com/repos/composer/semver/zipball/35e8d0af4486141bc745f23a29cc2091eb624a32",
+                "reference": "35e8d0af4486141bc745f23a29cc2091eb624a32",
                 "shasum": ""
             },
             "require": {
@@ -515,9 +515,9 @@
                 "versioning"
             ],
             "support": {
-                "irc": "irc://irc.freenode.org/composer",
+                "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.3.2"
+                "source": "https://github.com/composer/semver/tree/3.4.0"
             },
             "funding": [
                 {
@@ -533,7 +533,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-01T19:23:25+00:00"
+            "time": "2023-08-31T09:50:34+00:00"
         },
         {
             "name": "doctrine/annotations",
@@ -4953,7 +4953,7 @@
                 "rest"
             ],
             "support": {
-                "source": "https://github.com/oroinc/NelmioApiDocBundle/tree/ticket/BAP-22238"
+                "source": "https://github.com/oroinc/NelmioApiDocBundle/tree/2.1.0"
             },
             "time": "2023-09-13T11:08:54+00:00"
         },
@@ -5021,11 +5021,17 @@
         },
         {
             "name": "oro/platform-serialised-fields",
-            "version": "dev-master",
+            "version": "6.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/oroinc/OroEntitySerializedFieldsBundle.git",
+                "reference": "8600c8850f7ac6aae22b809b7c048c774794ee4f"
+            },
             "dist": {
-                "type": "path",
-                "url": "../serialized-fields",
-                "reference": "26995f4e406e22c5a026bac13550ffe15b284389"
+                "type": "zip",
+                "url": "https://api.github.com/repos/oroinc/OroEntitySerializedFieldsBundle/zipball/8600c8850f7ac6aae22b809b7c048c774794ee4f",
+                "reference": "8600c8850f7ac6aae22b809b7c048c774794ee4f",
+                "shasum": ""
             },
             "require": {
                 "oro/platform": "6.0.*"
@@ -5044,6 +5050,7 @@
                     "/Tests/"
                 ]
             },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "OSL-3.0"
             ],
@@ -5056,14 +5063,16 @@
             "description": "OroPlatform Serialized Fields",
             "homepage": "https://github.com/oroinc/OroEntitySerializedFieldsBundle",
             "keywords": [
-                "Oro",
-                "Platform",
+                "ORO",
                 "entity",
-                "fields"
+                "fields",
+                "platform"
             ],
-            "transport-options": {
-                "relative": true
-            }
+            "support": {
+                "issues": "https://github.com/oroinc/OroEntitySerializedFieldsBundle/issues",
+                "source": "https://github.com/oroinc/OroEntitySerializedFieldsBundle/tree/6.0.0"
+            },
+            "time": "2024-03-30T09:34:29+00:00"
         },
         {
             "name": "php-http/client-common",
@@ -5136,16 +5145,16 @@
         },
         {
             "name": "php-http/discovery",
-            "version": "1.19.2",
+            "version": "1.19.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-http/discovery.git",
-                "reference": "61e1a1eb69c92741f5896d9e05fb8e9d7e8bb0cb"
+                "reference": "0700efda8d7526335132360167315fdab3aeb599"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/discovery/zipball/61e1a1eb69c92741f5896d9e05fb8e9d7e8bb0cb",
-                "reference": "61e1a1eb69c92741f5896d9e05fb8e9d7e8bb0cb",
+                "url": "https://api.github.com/repos/php-http/discovery/zipball/0700efda8d7526335132360167315fdab3aeb599",
+                "reference": "0700efda8d7526335132360167315fdab3aeb599",
                 "shasum": ""
             },
             "require": {
@@ -5169,7 +5178,8 @@
                 "php-http/httplug": "^1.0 || ^2.0",
                 "php-http/message-factory": "^1.0",
                 "phpspec/phpspec": "^5.1 || ^6.1 || ^7.3",
-                "symfony/phpunit-bridge": "^6.2"
+                "sebastian/comparator": "^3.0.5 || ^4.0.8",
+                "symfony/phpunit-bridge": "^6.4.4 || ^7.0.1"
             },
             "type": "composer-plugin",
             "extra": {
@@ -5208,9 +5218,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-http/discovery/issues",
-                "source": "https://github.com/php-http/discovery/tree/1.19.2"
+                "source": "https://github.com/php-http/discovery/tree/1.19.4"
             },
-            "time": "2023-11-30T16:49:05+00:00"
+            "time": "2024-03-29T13:00:05+00:00"
         },
         {
             "name": "php-http/httplug",
@@ -8556,6 +8566,71 @@
                 }
             ],
             "time": "2023-10-31T17:30:12+00:00"
+        },
+        {
+            "name": "symfony/flex",
+            "version": "v2.4.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/flex.git",
+                "reference": "b0a405f40614c9f584b489d54f91091817b0e26e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/flex/zipball/b0a405f40614c9f584b489d54f91091817b0e26e",
+                "reference": "b0a405f40614c9f584b489d54f91091817b0e26e",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.1",
+                "php": ">=8.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.1",
+                "symfony/dotenv": "^5.4|^6.0",
+                "symfony/filesystem": "^5.4|^6.0",
+                "symfony/phpunit-bridge": "^5.4|^6.0",
+                "symfony/process": "^5.4|^6.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Symfony\\Flex\\Flex"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Flex\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien.potencier@gmail.com"
+                }
+            ],
+            "description": "Composer plugin for Symfony",
+            "support": {
+                "issues": "https://github.com/symfony/flex/issues",
+                "source": "https://github.com/symfony/flex/tree/v2.4.5"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-03-02T08:16:47+00:00"
         },
         {
             "name": "symfony/form",
@@ -13744,52 +13819,49 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.13.2",
+            "version": "v3.52.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "3952f08a81bd3b1b15e11c3de0b6bf037faa8496"
+                "reference": "6e77207f0d851862ceeb6da63e6e22c01b1587bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/3952f08a81bd3b1b15e11c3de0b6bf037faa8496",
-                "reference": "3952f08a81bd3b1b15e11c3de0b6bf037faa8496",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/6e77207f0d851862ceeb6da63e6e22c01b1587bc",
+                "reference": "6e77207f0d851862ceeb6da63e6e22c01b1587bc",
                 "shasum": ""
             },
             "require": {
-                "composer/semver": "^3.2",
+                "composer/semver": "^3.4",
                 "composer/xdebug-handler": "^3.0.3",
-                "doctrine/annotations": "^1.13",
+                "ext-filter": "*",
                 "ext-json": "*",
                 "ext-tokenizer": "*",
                 "php": "^7.4 || ^8.0",
-                "sebastian/diff": "^4.0",
-                "symfony/console": "^5.4 || ^6.0",
-                "symfony/event-dispatcher": "^5.4 || ^6.0",
-                "symfony/filesystem": "^5.4 || ^6.0",
-                "symfony/finder": "^5.4 || ^6.0",
-                "symfony/options-resolver": "^5.4 || ^6.0",
-                "symfony/polyfill-mbstring": "^1.23",
-                "symfony/polyfill-php80": "^1.25",
-                "symfony/polyfill-php81": "^1.25",
-                "symfony/process": "^5.4 || ^6.0",
-                "symfony/stopwatch": "^5.4 || ^6.0"
+                "sebastian/diff": "^4.0 || ^5.0 || ^6.0",
+                "symfony/console": "^5.4 || ^6.0 || ^7.0",
+                "symfony/event-dispatcher": "^5.4 || ^6.0 || ^7.0",
+                "symfony/filesystem": "^5.4 || ^6.0 || ^7.0",
+                "symfony/finder": "^5.4 || ^6.0 || ^7.0",
+                "symfony/options-resolver": "^5.4 || ^6.0 || ^7.0",
+                "symfony/polyfill-mbstring": "^1.28",
+                "symfony/polyfill-php80": "^1.28",
+                "symfony/polyfill-php81": "^1.28",
+                "symfony/process": "^5.4 || ^6.0 || ^7.0",
+                "symfony/stopwatch": "^5.4 || ^6.0 || ^7.0"
             },
             "require-dev": {
+                "facile-it/paraunit": "^1.3 || ^2.0",
                 "justinrainbow/json-schema": "^5.2",
-                "keradus/cli-executor": "^2.0",
-                "mikey179/vfsstream": "^1.6.10",
-                "php-coveralls/php-coveralls": "^2.5.2",
+                "keradus/cli-executor": "^2.1",
+                "mikey179/vfsstream": "^1.6.11",
+                "php-coveralls/php-coveralls": "^2.7",
                 "php-cs-fixer/accessible-object": "^1.1",
-                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.2",
-                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.2.1",
-                "phpspec/prophecy": "^1.15",
-                "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.5",
-                "phpunitgoodpractices/polyfill": "^1.6",
-                "phpunitgoodpractices/traits": "^1.9.2",
-                "symfony/phpunit-bridge": "^6.0",
-                "symfony/yaml": "^5.4 || ^6.0"
+                "php-cs-fixer/phpunit-constraint-isidenticalstring": "^1.4",
+                "php-cs-fixer/phpunit-constraint-xmlmatchesxsd": "^1.4",
+                "phpunit/phpunit": "^9.6 || ^10.5.5 || ^11.0.2",
+                "symfony/var-dumper": "^5.4 || ^6.0 || ^7.0",
+                "symfony/yaml": "^5.4 || ^6.0 || ^7.0"
             },
             "suggest": {
                 "ext-dom": "For handling output formats in XML",
@@ -13819,9 +13891,15 @@
                 }
             ],
             "description": "A tool to automatically fix PHP code style",
+            "keywords": [
+                "Static code analysis",
+                "fixer",
+                "standards",
+                "static analysis"
+            ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.13.2"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.52.1"
             },
             "funding": [
                 {
@@ -13829,7 +13907,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-02T23:53:50+00:00"
+            "time": "2024-03-19T21:02:43+00:00"
         },
         {
             "name": "instaclick/php-webdriver",
@@ -14167,18 +14245,24 @@
         },
         {
             "name": "oro/twig-inspector",
-            "version": "dev-master",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/oroinc/twig-inspector.git",
+                "reference": "1d17b5590be7939b94d80658193f8418c3c248bc"
+            },
             "dist": {
-                "type": "path",
-                "url": "../twig-inspector",
-                "reference": "6ec311c40e5cc491957e9f59b36d31009e58304a"
+                "type": "zip",
+                "url": "https://api.github.com/repos/oroinc/twig-inspector/zipball/1d17b5590be7939b94d80658193f8418c3c248bc",
+                "reference": "1d17b5590be7939b94d80658193f8418c3c248bc",
+                "shasum": ""
             },
             "require": {
                 "php": ">=7.4",
                 "symfony/config": "^4.4.1 | ^5.0 | ^6.0",
                 "symfony/dependency-injection": "^4.4.1 | ^5.0 | ^6.0",
                 "symfony/http-foundation": "^4.4.1 | ^5.0 | ^6.0",
-                "symfony/http-kernel": "^4.4.13 | ^5.1.5 | ^6.0",
+                "symfony/http-kernel": "^4.4.1 | ^5.0 | ^6.0",
                 "symfony/routing": "^4.4.1 | ^5.0 | ^6.0",
                 "symfony/web-profiler-bundle": "^4.4.1 | ^5.0 | ^6.0",
                 "twig/twig": "^1.38 | ^2.7 | ^3.0"
@@ -14194,6 +14278,7 @@
                     "Oro\\TwigInspector\\": ""
                 }
             },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
             ],
@@ -14214,9 +14299,11 @@
                 "toolbar-extension",
                 "twig"
             ],
-            "transport-options": {
-                "relative": true
-            }
+            "support": {
+                "issues": "https://github.com/oroinc/twig-inspector/issues",
+                "source": "https://github.com/oroinc/twig-inspector/tree/1.1.0"
+            },
+            "time": "2022-01-08T13:54:33+00:00"
         },
         {
             "name": "pdepend/pdepend",
@@ -16683,5 +16770,5 @@
         "composer-plugin-api": "^2.1"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
Allow to install more recent packages of `composer/semver` and `friendsofphp/php-cs-fixer`

I'm not quite sure how to update `dev.json` and `dev.lock` there are some slight differences. If you like i can also remove these files from the PR.

Thx Eric