### PR TITLE
fix: correct syntax in ImapBundle processes.yml configuration

### DIFF
--- a/src/Oro/Bundle/ImapBundle/Resources/config/oro/processes.yml
+++ b/src/Oro/Bundle/ImapBundle/Resources/config/oro/processes.yml
@@ -32,7 +32,7 @@ processes:
                     method: 'send'
                     method_parameters:
                         - '$.topic'
-                        - { id: $origin.id }`
+                        - { id: $origin.id }
 
     triggers:
         clear_user_email_origin_on_deactivation:


### PR DESCRIPTION
Fixed a syntax issue in the ImapBundle processes.yml configuration file that was preventing Oro installation and updates from completing successfully.