### PR TITLE
Improve CSS and JS loading Asset.html.twig

### DIFF
--- a/src/Oro/Bundle/AssetBundle/Resources/views/Asset.html.twig
+++ b/src/Oro/Bundle/AssetBundle/Resources/views/Asset.html.twig
@@ -1,13 +1,28 @@
 {% macro css(src, extra_attributes) %}
-    {% if webpack_hmr_enabled() %}
+   {% if webpack_hmr_enabled() %}
         <script src="{{ asset(src|webpack_asset) }}"></script>
     {% else %}
-        <link rel="stylesheet" {{ extra_attributes|raw }} href="{{ asset(src) }}">
+         {% if 'styles-print' in src %}
+            <script>
+                document.addEventListener('DOMContentLoaded', function(){
+                const link = document.createElement('link');
+                link.rel = 'stylesheet';
+                link.href='{{ asset(src) }}';
+                link.media = 'print';
+                document.head.appendChild(link);
+                });
+            </script>
+            <noscript>
+                <link rel="stylesheet" {{ extra_attributes|raw }} href="{{ asset(src) }}">
+            </noscript>
+        {% else %}
+            <link rel="stylesheet" {{ extra_attributes|raw }} href="{{ asset(src) }}">
+        {% endif %}
     {% endif %}
 {% endmacro %}
 
 {% macro js(src) %}
-    <script src="{{ asset(src) }}"></script>
+    <script defer src="{{ asset(src) }}"></script>
 {% endmacro %}
 
 {% macro js_modules_config(config) %}


### PR DESCRIPTION
Using the defer attribute in script tags is generally considered better than placing JavaScript at the end of the HTML file because it offers several advantages related to page loading and performance:

1. Improved Parsing and Loading Performance:
When a script tag uses defer, the browser downloads the script file asynchronously, without pausing the HTML parsing.
Scripts placed at the end of the file still block rendering at the point they are encountered until fully downloaded and executed.

2. Maintainability and Readability:
Scripts using defer can be placed in the HTML <head>, clearly defining dependencies upfront rather than scattering script tags throughout the HTML file.
This improves maintainability, readability, and makes it easier for developers to manage and track JavaScript dependencies.

3. Automatic Execution Order:
defer scripts execute in the order they appear in the HTML document, which is particularly useful when scripts depend on each other.
Placing scripts manually at the end of the file can become error-prone as the number of scripts grows.

4. Better Handling of Dependencies:
Using defer ensures scripts run only after the DOM has fully loaded (DOMContentLoaded event), removing the need for manual event listeners such as DOMContentLoaded or window.onload.

Scripts at the end of HTML might still require explicit event listeners to ensure DOM readiness.

Loading a print CSS file dynamically via JavaScript rather than using <link rel="stylesheet" media="print"> has several advantages, primarily in terms of page loading performance and user experience:

1. Avoids Unnecessary HTTP Requests on page load
Modern browsers typically download print CSS files even if the user doesn't print the page. This adds an unnecessary HTTP traffic increasing initial page load time.

Loading via JavaScript solves this issue by downloading the print CSS file after page is loaded. 